### PR TITLE
mgmt: Declare Terraform state S3 backend resources

### DIFF
--- a/accounts/mgmt/dev/main.tf
+++ b/accounts/mgmt/dev/main.tf
@@ -7,4 +7,6 @@ module "account_baseline" {
 # This module declares all resources specific to management accounts.
 module "mgmt_resources" {
   source = "../resources"
+
+  stage = "dev"
 }

--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -1,0 +1,128 @@
+## -------------------------------------------------------------------------------------
+## TERRAFORM STATE S3 BACKEND
+## -------------------------------------------------------------------------------------
+
+# Bucket for storing Terraform state files for all accounts belonging to this stage. In
+# the future, it might make sense to encrypt files in this bucket with a customer
+# managed KMS key for enhanced access control & logging (or just to check a compliance
+# box). But for now relying on the default SSE-S3 encryption is the simplest & cheapest
+# approach.
+resource "aws_s3_bucket" "tf_state" {
+  # Prefix with "devshrekops-" to reduce chance of naming collision with other customers
+  # and include "demo-" to reduce chance of naming collision with other DevShrekOps
+  # projects.
+  bucket = "devshrekops-demo-tf-state-${var.stage}"
+}
+
+# Versioning makes it easier to recover deleted or corrupted state files
+resource "aws_s3_bucket_versioning" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# Disable ACLs because they're an unnecessary, legacy form of access control, instead
+# relying on bucket policies and IAM to govern access to the bucket.
+resource "aws_s3_bucket_ownership_controls" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+# Prevent a misconfiguration that could make the bucket publicly accessible. This
+# probably isn't necessary since I plan on enabling this control at the account layer.
+# At a minimum, it might check a compliance box.
+resource "aws_s3_bucket_public_access_block" "tf_state" {
+  bucket = aws_s3_bucket.tf_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Table for managing Terraform state locks for all accounts belonging to this stage. In
+# the future, it might make sense to encrypt files in this table with a customer managed
+# KMS key for enhanced access control & logging (or just to check a compliance box). But
+# for now relying on the default SSE-S3 encryption is the simplest & cheapest approach.
+resource "aws_dynamodb_table" "tf_state_locks" {
+  name = "tf-state-locks-${var.stage}"
+
+  hash_key     = "LockID"          # Required per Terraform docs for DynamoDB State Locking
+  billing_mode = "PAY_PER_REQUEST" # Should be within free tier for this demo
+
+  # Required per Terraform docs for DynamoDB State Locking
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}
+
+# Role for managing state. Technically the deployer role could be used instead (or even
+# the developer's SSO user or future pipeline's role). I'm not sure how much (if any)
+# value there is in using a separate role for state management, but for some reason it
+# feels cleaner despite the extra code, so I'm going with it for this demo.
+resource "aws_iam_role" "tf_state_manager" {
+  name = "tf-state-manager-${var.stage}"
+
+  # Allow same-account, sufficiently-privileged principals to assume this role
+  assume_role_policy = data.aws_iam_policy_document.tf_state_manager_trust.json
+
+  # Allow this role to read from & write to the state bucket & table for this stage
+  inline_policy {
+    name   = "manage-tf-state"
+    policy = data.aws_iam_policy_document.tf_state_manager_inline.json
+  }
+}
+
+# Fetch the account ID & partition of the current AWS account
+data "aws_caller_identity" "main" {}
+data "aws_partition" "main" {}
+
+# Store as local values for easier referencing
+locals {
+  account_id = data.aws_caller_identity.main.account_id
+  partition  = data.aws_partition.main.partition
+}
+
+data "aws_iam_policy_document" "tf_state_manager_trust" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:${local.partition}:iam::${local.account_id}:root"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "tf_state_manager_inline" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [aws_s3_bucket.tf_state.arn]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject", "s3:PutObject"]
+    resources = ["${aws_s3_bucket.tf_state.arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+    ]
+    resources = [aws_dynamodb_table.tf_state_locks.arn]
+  }
+}

--- a/accounts/mgmt/resources/variables.tf
+++ b/accounts/mgmt/resources/variables.tf
@@ -1,0 +1,9 @@
+## -------------------------------------------------------------------------------------
+## REQUIRED INPUT VARIABLES
+## -------------------------------------------------------------------------------------
+
+variable "stage" {
+  description = "Deployment stage (e.g., dev or prod)."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
Edit: I failed to capture the `terraform plan` for this PR, but you can view a similar plan for mgmt-prod in #72. Just ignore the imports & unrelated resources in that plan.