### PR TITLE
account-baseline: Declare account alias

### DIFF
--- a/accounts/mgmt/dev/main.tf
+++ b/accounts/mgmt/dev/main.tf
@@ -2,6 +2,9 @@
 # in this demo.
 module "account_baseline" {
   source = "../../../modules/account-baseline"
+
+  stage        = "dev"
+  account_type = "mgmt"
 }
 
 # This module declares all resources specific to management accounts.

--- a/modules/account-baseline/main.tf
+++ b/modules/account-baseline/main.tf
@@ -1,0 +1,10 @@
+## -------------------------------------------------------------------------------------
+## ACCOUNT ALIAS
+## -------------------------------------------------------------------------------------
+
+# Prefix with "devshrekops-" to reduce chance of naming collision with other customers
+# and include "demo-" to reduce chance of naming collision with other DevShrekOps
+# projects.
+resource "aws_iam_account_alias" "main" {
+  account_alias = "devshrekops-demo-${var.account_type}-${var.stage}"
+}

--- a/modules/account-baseline/outputs.tf
+++ b/modules/account-baseline/outputs.tf
@@ -1,0 +1,4 @@
+output "account_alias" {
+  description = "Globally unique alias of this account."
+  value       = aws_iam_account_alias.main.account_alias
+}

--- a/modules/account-baseline/variables.tf
+++ b/modules/account-baseline/variables.tf
@@ -1,0 +1,15 @@
+## -------------------------------------------------------------------------------------
+## REQUIRED INPUT VARIABLES
+## -------------------------------------------------------------------------------------
+
+variable "stage" {
+  description = "Deployment stage (e.g., dev or prod)."
+  type        = string
+  nullable    = false
+}
+
+variable "account_type" {
+  description = "Account type (e.g., mgmt, sec, or net)."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
Terraform plan for **mgmt-dev**:

```
Terraform will perform the following actions:

  # module.account_baseline.aws_iam_account_alias.main will be created
  + resource "aws_iam_account_alias" "main" {
      + account_alias = "devshrekops-demo-mgmt-dev"
      + id            = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ account_baseline = {
      + account_alias = "devshrekops-demo-mgmt-dev"
    }
```