### PR TITLE
account-baseline: Declare S3 public access block

### DIFF
--- a/modules/account-baseline/main.tf
+++ b/modules/account-baseline/main.tf
@@ -8,3 +8,15 @@
 resource "aws_iam_account_alias" "main" {
   account_alias = "devshrekops-demo-${var.account_type}-${var.stage}"
 }
+
+## -------------------------------------------------------------------------------------
+## S3 ACCOUNT PUBLIC ACCESS BLOCK
+## -------------------------------------------------------------------------------------
+
+# Drastically reduce the chances of an S3 bucket being accidentally opened to the public
+resource "aws_s3_account_public_access_block" "main" {
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}


### PR DESCRIPTION
Terraform plan for **mgmt-dev**:

```
Terraform will perform the following actions:

  # module.account_baseline.aws_s3_account_public_access_block.main will be created
  + resource "aws_s3_account_public_access_block" "main" {
      + account_id              = (known after apply)
      + block_public_acls       = true
      + block_public_policy     = true
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```