### PR TITLE
refactor: Rename "account type" to "account key"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Demo multi-account AWS Organization created mostly with Terraform.
 
 ## AWS Accounts
 
-Each AWS account in this demo is represented by its own Terraform root module in the **accounts/\<account-type>/\<stage>/** directory. For example, the root module for the dev management account is located in **accounts/mgmt/dev/**.
+Each AWS account in this demo is represented by its own Terraform root module in the **accounts/\<account-key>/\<stage>/** directory. For example, the root module for the dev management account is located in **accounts/mgmt/dev/**.
 
-Each account type has its own **resources** child module in the **accounts/\<account-type>/resources/** directory that declares all resources specific to the account type. For example, the **resources** child module for management accounts is located in **accounts/mgmt/resources/** and it declares all the resources specific to management accounts.
+Each account key has its own **resources** child module in the **accounts/\<account-key>/resources/** directory that declares all resources specific to the account key. For example, the **resources** child module for management accounts is located in **accounts/mgmt/resources/** and it declares all the resources specific to management accounts.
 
-The **resources** child module is called by each root module representing an account of the same type. For example, the **resources** child module for management accounts is called by the root modules for both the prod & dev management accounts. This helps reduce duplication and lower the risk of drift between prod & dev versions of the same account type.
+The **resources** child module is called by each root module representing an account with the same key. For example, the **resources** child module for management accounts is called by the root modules for both the prod & dev management accounts. This helps reduce duplication and lower the risk of drift between prod & dev versions with the same account key.
 
 In the future, it might make sense to have multiple root modules representing different aspects of the same account. But for now having one root module per account is the simplest approach.
 

--- a/accounts/mgmt/dev/main.tf
+++ b/accounts/mgmt/dev/main.tf
@@ -3,8 +3,8 @@
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
-  stage        = "dev"
-  account_type = "mgmt"
+  stage       = "dev"
+  account_key = "mgmt"
 }
 
 # This module declares all resources specific to management accounts.

--- a/accounts/mgmt/prod/main.tf
+++ b/accounts/mgmt/prod/main.tf
@@ -3,8 +3,8 @@
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
-  stage        = "prod"
-  account_type = "mgmt"
+  stage       = "prod"
+  account_key = "mgmt"
 }
 
 # This module declares all resources specific to management accounts.

--- a/accounts/sec/dev/main.tf
+++ b/accounts/sec/dev/main.tf
@@ -3,6 +3,6 @@
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
-  stage        = "dev"
-  account_type = "sec"
+  stage       = "dev"
+  account_key = "sec"
 }

--- a/accounts/sec/prod/main.tf
+++ b/accounts/sec/prod/main.tf
@@ -3,6 +3,6 @@
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
-  stage        = "prod"
-  account_type = "sec"
+  stage       = "prod"
+  account_key = "sec"
 }

--- a/modules/account-baseline/main.tf
+++ b/modules/account-baseline/main.tf
@@ -6,7 +6,7 @@
 # and include "demo-" to reduce chance of naming collision with other DevShrekOps
 # projects.
 resource "aws_iam_account_alias" "main" {
-  account_alias = "devshrekops-demo-${var.account_type}-${var.stage}"
+  account_alias = "devshrekops-demo-${var.account_key}-${var.stage}"
 }
 
 ## -------------------------------------------------------------------------------------

--- a/modules/account-baseline/variables.tf
+++ b/modules/account-baseline/variables.tf
@@ -8,8 +8,8 @@ variable "stage" {
   nullable    = false
 }
 
-variable "account_type" {
-  description = "Account type (e.g., mgmt, sec, or net)."
+variable "account_key" {
+  description = "Account key (e.g., mgmt, sec, or net)."
   type        = string
   nullable    = false
 }


### PR DESCRIPTION
Terraform plan for **mgmt-dev**, **mgmt-prod**, **sec-dev**, & **sec-prod**:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
```