### PR TITLE
mgmt: Grant org admins access to all accounts

### DIFF
--- a/accounts/mgmt/dev/imports.tf
+++ b/accounts/mgmt/dev/imports.tf
@@ -37,7 +37,7 @@ import {
 # Import the assignment of the org-admins-dev SSO group with the full-admin-access-dev
 # SSO permission set to the mgmt-dev account that was manually created in this account.
 import {
-  to = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt
+  to = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
   id = join(",", [
     "94784418-7091-7068-2428-0b327809cf24",
     "GROUP",
@@ -46,6 +46,12 @@ import {
     "arn:aws:sso:::permissionSet/ssoins-722327f2538a7b72/ps-8ba4e82e9024cb37",
     "arn:aws:sso:::instance/ssoins-722327f2538a7b72",
   ])
+}
+
+# Moved due to refactoring when granting org admins access to all accounts in the org.
+moved {
+  from = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt
+  to   = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
 }
 
 # Import the donkey SSO user that was manually created in this account.

--- a/accounts/mgmt/prod/imports.tf
+++ b/accounts/mgmt/prod/imports.tf
@@ -37,7 +37,7 @@ import {
 # Import the assignment of the org-admins-prod SSO group with the full-admin-access-prod
 # SSO permission set to the mgmt-prod account that was manually created in this account.
 import {
-  to = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt
+  to = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
   id = join(",", [
     "04183448-d091-70b1-7e76-5f2ebfdc549e",
     "GROUP",
@@ -46,6 +46,12 @@ import {
     "arn:aws:sso:::permissionSet/ssoins-72232a1562dbd133/ps-a095036f1fc365cf",
     "arn:aws:sso:::instance/ssoins-72232a1562dbd133",
   ])
+}
+
+# Moved due to refactoring when granting org admins access to all accounts in the org.
+moved {
+  from = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt
+  to   = module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
 }
 
 # Import the donkey SSO user that was manually created in this account.

--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -97,7 +97,7 @@ resource "aws_ssoadmin_managed_policy_attachment" "full_admin" {
   # assignments is necessary "to ensure proper deletion order" if this resource is
   # deleted "because destruction of a managed policy attachment resource also
   # re-provisions the associated permission set to all accounts."
-  depends_on = [aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt]
+  depends_on = [aws_ssoadmin_account_assignment.org_admins_full_admin]
 }
 
 resource "aws_identitystore_group" "org_admins" {
@@ -107,15 +107,17 @@ resource "aws_identitystore_group" "org_admins" {
   identity_store_id = local.sso_identity_store_id
 }
 
-# Grant org admins full admin access to the management account
-resource "aws_ssoadmin_account_assignment" "org_admins_full_admin_mgmt" {
+# Grant org admins full admin access to every account
+resource "aws_ssoadmin_account_assignment" "org_admins_full_admin" {
+  for_each = aws_organizations_account.main
+
   principal_type = "GROUP"
   principal_id   = aws_identitystore_group.org_admins.group_id
 
   permission_set_arn = aws_ssoadmin_permission_set.full_admin.arn
 
   target_type = "AWS_ACCOUNT"
-  target_id   = local.account_id
+  target_id   = each.value.id
 
   instance_arn = local.sso_instance_arn
 }


### PR DESCRIPTION
Terraform plan in mgmt-dev:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt has moved to module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
    resource "aws_ssoadmin_account_assignment" "org_admins_full_admin" {
        id                 = "94784418-7091-7068-2428-0b327809cf24,GROUP,533266992459,AWS_ACCOUNT,arn:aws:sso:::permissionSet/ssoins-722327f2538a7b72/ps-8ba4e82e9024cb37,arn:aws:sso:::instance/ssoins-722327f2538a7b72"
        # (6 unchanged attributes hidden)
    }

  # module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["sec"] will be created
  + resource "aws_ssoadmin_account_assignment" "org_admins_full_admin" {
      + id                 = (known after apply)
      + instance_arn       = "arn:aws:sso:::instance/ssoins-722327f2538a7b72"
      + permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-722327f2538a7b72/ps-8ba4e82e9024cb37"
      + principal_id       = "94784418-7091-7068-2428-0b327809cf24"
      + principal_type     = "GROUP"
      + target_id          = "891377308296"
      + target_type        = "AWS_ACCOUNT"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Terraform plan in mgmt-prod:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin_mgmt has moved to module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["mgmt"]
    resource "aws_ssoadmin_account_assignment" "org_admins_full_admin" {
        id                 = "04183448-d091-70b1-7e76-5f2ebfdc549e,GROUP,339712815005,AWS_ACCOUNT,arn:aws:sso:::permissionSet/ssoins-72232a1562dbd133/ps-a095036f1fc365cf,arn:aws:sso:::instance/ssoins-72232a1562dbd133"
        # (6 unchanged attributes hidden)
    }

  # module.mgmt_resources.aws_ssoadmin_account_assignment.org_admins_full_admin["sec"] will be created
  + resource "aws_ssoadmin_account_assignment" "org_admins_full_admin" {
      + id                 = (known after apply)
      + instance_arn       = "arn:aws:sso:::instance/ssoins-72232a1562dbd133"
      + permission_set_arn = "arn:aws:sso:::permissionSet/ssoins-72232a1562dbd133/ps-a095036f1fc365cf"
      + principal_id       = "04183448-d091-70b1-7e76-5f2ebfdc549e"
      + principal_type     = "GROUP"
      + target_id          = "590183735431"
      + target_type        = "AWS_ACCOUNT"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```