### PR TITLE
baseline-s3-bucket: Support extra policy documents

### DIFF
--- a/modules/baseline-s3-bucket/main.tf
+++ b/modules/baseline-s3-bucket/main.tf
@@ -36,10 +36,11 @@ resource "aws_s3_bucket_policy" "main" {
   policy = data.aws_iam_policy_document.baseline_bucket_policy.json
 }
 
-# Require requests to be encrypted in transit with TLS v1.3 or newer (to future-proof).
-# In the future, it may become necessary to make the version configurable and/or lower
-# the default to v1.2, depending on the frequency of compatibility issues.
 data "aws_iam_policy_document" "baseline_bucket_policy" {
+  # Require requests to be encrypted in transit with TLS v1.3 or newer (to
+  # future-proof). In the future, it may become necessary to make the version
+  # configurable and/or lower the default to v1.2, depending on the frequency of
+  # compatibility issues.
   statement {
     sid    = "RequireLatestTLS"
     effect = "Deny"
@@ -61,4 +62,7 @@ data "aws_iam_policy_document" "baseline_bucket_policy" {
       values   = [1.3]
     }
   }
+
+  # Append any extra bucket policy documents that were passed in via a variable
+  source_policy_documents = var.extra_bucket_policy_documents
 }

--- a/modules/baseline-s3-bucket/variables.tf
+++ b/modules/baseline-s3-bucket/variables.tf
@@ -13,3 +13,17 @@ variable "scope" {
   type        = string
   nullable    = false
 }
+
+## -------------------------------------------------------------------------------------
+## OPTIONAL INPUT VARIABLES
+## -------------------------------------------------------------------------------------
+
+variable "extra_bucket_policy_documents" {
+  description = <<EOT
+    Bucket policy documents to append to the baseline bucket policy. Documents must be
+    in JSON format.
+  EOT
+  type        = list(string)
+  nullable    = false
+  default     = []
+}


### PR DESCRIPTION
Terraform plan for **mgmt-dev** and **mgmt-prod**:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
```

Example Terraform plan if adding an extra policy with sid "test":

```
erraform will perform the following actions:

  # module.mgmt_resources.module.tf_state_baseline_s3_bucket.aws_s3_bucket_policy.main will be updated in-place
  ~ resource "aws_s3_bucket_policy" "main" {
        id     = "devshrekops-demo-tf-state-dev"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  + {
                      + Action    = "s3:*"
                      + Condition = {
                          + NumericLessThan = {
                              + "s3:TlsVersion" = "1.2"
                            }
                        }
                      + Effect    = "Deny"
                      + Principal = "*"
                      + Resource  = "devshrekops-demo-tf-state-dev"
                      + Sid       = "test"
                    },
                    {
                        Action    = "s3:*"
                        Condition = {
                            NumericLessThan = {
                                "s3:TlsVersion" = "1.3"
                            }
                        }
                        Effect    = "Deny"
                        Principal = "*"
                        Resource  = [
                            "arn:aws:s3:::devshrekops-demo-tf-state-dev/*",
                            "arn:aws:s3:::devshrekops-demo-tf-state-dev",
                        ]
                        Sid       = "RequireLatestTLS"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        # (1 unchanged attribute hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```