### PR TITLE
sec: Add child module for resources

### DIFF
--- a/accounts/sec/dev/main.tf
+++ b/accounts/sec/dev/main.tf
@@ -6,3 +6,10 @@ module "account_baseline" {
   stage       = "dev"
   account_key = "sec"
 }
+
+# This module declares all resources specific to security accounts.
+module "sec_resources" {
+  source = "../resources"
+
+  stage = "dev"
+}

--- a/accounts/sec/dev/outputs.tf
+++ b/accounts/sec/dev/outputs.tf
@@ -2,3 +2,8 @@ output "account_baseline" {
   description = "All outputs from the account_baseline module."
   value       = module.account_baseline
 }
+
+output "sec_resources" {
+  description = "All outputs from the sec_resources module."
+  value       = module.sec_resources
+}

--- a/accounts/sec/prod/main.tf
+++ b/accounts/sec/prod/main.tf
@@ -6,3 +6,10 @@ module "account_baseline" {
   stage       = "prod"
   account_key = "sec"
 }
+
+# This module declares all resources specific to security accounts.
+module "sec_resources" {
+  source = "../resources"
+
+  stage = "prod"
+}

--- a/accounts/sec/prod/outputs.tf
+++ b/accounts/sec/prod/outputs.tf
@@ -2,3 +2,8 @@ output "account_baseline" {
   description = "All outputs from the account_baseline module."
   value       = module.account_baseline
 }
+
+output "sec_resources" {
+  description = "All outputs from the sec_resources module."
+  value       = module.sec_resources
+}

--- a/accounts/sec/resources/README.md
+++ b/accounts/sec/resources/README.md
@@ -1,0 +1,3 @@
+# sec-resources
+
+Terraform child module that declares all resources specific to security accounts.

--- a/accounts/sec/resources/config.tf
+++ b/accounts/sec/resources/config.tf
@@ -1,0 +1,15 @@
+# See README.md in this repo's root directory for commentary on this file.
+
+## -------------------------------------------------------------------------------------
+## VERSIONS
+## -------------------------------------------------------------------------------------
+
+terraform {
+  required_version = "~> 1.7.0"
+
+  required_providers {
+    aws = {
+      version = "~> 5.39"
+    }
+  }
+}

--- a/accounts/sec/resources/main.tf
+++ b/accounts/sec/resources/main.tf
@@ -1,0 +1,1 @@
+# Placeholder

--- a/accounts/sec/resources/outputs.tf
+++ b/accounts/sec/resources/outputs.tf
@@ -1,0 +1,1 @@
+# Placeholder

--- a/accounts/sec/resources/variables.tf
+++ b/accounts/sec/resources/variables.tf
@@ -1,0 +1,9 @@
+## -------------------------------------------------------------------------------------
+## REQUIRED INPUT VARIABLES
+## -------------------------------------------------------------------------------------
+
+variable "stage" {
+  description = "Deployment stage (e.g., dev or prod)."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
Terraform plan for **sec-dev** and **sec-prod**:

```
Changes to Outputs:
  + sec_resources    = {}

You can apply this plan to save these new output values to the Terraform state, without changing any
real infrastructure.
```