### PR TITLE
mgmt: Move account_keys into mgmt-resources

### DIFF
--- a/accounts/mgmt/dev/main.tf
+++ b/accounts/mgmt/dev/main.tf
@@ -6,11 +6,6 @@
 # split it up into one or more separate files, but for now I'd rather have this file be
 # longer than there be more files in the directory.
 locals {
-  account_keys = [
-    "mgmt", # management account
-    "sec",  # security account
-  ]
-
   sso_users = [
     {
       username     = "donkey"
@@ -44,7 +39,6 @@ module "mgmt_resources" {
   source = "../resources"
 
   stage          = "dev"
-  account_keys   = local.account_keys
   sso_users      = local.sso_users
   sso_org_admins = local.sso_org_admins
 }

--- a/accounts/mgmt/prod/main.tf
+++ b/accounts/mgmt/prod/main.tf
@@ -6,11 +6,6 @@
 # split it up into one or more separate files, but for now I'd rather have this file be
 # longer than there be more files in the directory.
 locals {
-  account_keys = [
-    "mgmt", # management account
-    "sec",  # security account
-  ]
-
   sso_users = [
     {
       username     = "donkey"
@@ -44,7 +39,6 @@ module "mgmt_resources" {
   source = "../resources"
 
   stage          = "prod"
-  account_keys   = local.account_keys
   sso_users      = local.sso_users
   sso_org_admins = local.sso_org_admins
 }

--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -16,6 +16,13 @@ locals {
 ## ORGANIZATION
 ## -------------------------------------------------------------------------------------
 
+locals {
+  account_keys = [
+    "mgmt", # management account
+    "sec",  # security account
+  ]
+}
+
 # Declare an org resource so that manually-created orgs can be imported into and managed
 # by Terraform as additional service integrations & policy types are enabled over time.
 resource "aws_organizations_organization" "main" {
@@ -32,7 +39,7 @@ resource "aws_organizations_account" "main" {
   # The for_each uses account key as the key (as opposed to a numeric index) for more
   # expressive plans & state files and so that if an account is removed from the list it
   # doesn't impact other accounts.
-  for_each = toset(var.account_keys)
+  for_each = toset(local.account_keys)
 
   name  = "demo-${each.key}-${var.stage}"
   email = "devshrekops+demo-${each.key}-${var.stage}@gmail.com"

--- a/accounts/mgmt/resources/variables.tf
+++ b/accounts/mgmt/resources/variables.tf
@@ -12,16 +12,6 @@ variable "stage" {
 ## OPTIONAL INPUT VARIABLES
 ## -------------------------------------------------------------------------------------
 
-variable "account_keys" {
-  description = <<EOT
-    Keys of accounts to create in the org. An account's key is included in its name and
-    email.
-  EOT
-  type        = list(string)
-  default     = []
-  nullable    = false
-}
-
 variable "sso_org_admins" {
   description = <<EOT
     Usernames of SSO users to add to org admins group in IAM Identity Center. All users


### PR DESCRIPTION
Terraform plan for **mgmt-dev** and **mgmt-prod**:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
```