### PR TITLE
105 prep mgmt for cloudtrail

### DIFF
--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -24,6 +24,7 @@ resource "aws_organizations_organization" "main" {
 
   # Integrate the org with other services (e.g., IAM Identity Center)
   aws_service_access_principals = [
+    "cloudtrail.amazonaws.com",
     "sso.amazonaws.com", # IAM Identity Center
   ]
 }

--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -70,6 +70,15 @@ resource "aws_organizations_account" "main" {
   }
 }
 
+# Enable the security account to create an org CloudTrail. There's probably not much
+# benefit (if any) to delegating creation to the security account (as opposed to the
+# management account creating it) unless the security & management accounts are managed
+# by separate teams, but I'm doing it anyway as a general best practice.
+resource "aws_organizations_delegated_administrator" "cloudtrail_sec" {
+  service_principal = "cloudtrail.amazonaws.com"
+  account_id        = aws_organizations_account.main["sec"].id
+}
+
 ## -------------------------------------------------------------------------------------
 ## IAM IDENTITY CENTER (SSO)
 ## -------------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform plan for **mgmt-dev**:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_organizations_delegated_administrator.cloudtrail_sec will be created
  + resource "aws_organizations_delegated_administrator" "cloudtrail_sec" {
      + account_id              = "891377308296"
      + arn                     = (known after apply)
      + delegation_enabled_date = (known after apply)
      + email                   = (known after apply)
      + id                      = (known after apply)
      + joined_method           = (known after apply)
      + joined_timestamp        = (known after apply)
      + name                    = (known after apply)
      + service_principal       = "cloudtrail.amazonaws.com"
      + status                  = (known after apply)
    }

  # module.mgmt_resources.aws_organizations_organization.main will be updated in-place
  ~ resource "aws_organizations_organization" "main" {
      ~ aws_service_access_principals = [
          + "cloudtrail.amazonaws.com",
            # (1 unchanged element hidden)
        ]
        id                            = "o-pca28idqmq"
        # (9 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```

Terraform plan for **mgmt-prod**:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_organizations_delegated_administrator.cloudtrail_sec will be created
  + resource "aws_organizations_delegated_administrator" "cloudtrail_sec" {
      + account_id              = "590183735431"
      + arn                     = (known after apply)
      + delegation_enabled_date = (known after apply)
      + email                   = (known after apply)
      + id                      = (known after apply)
      + joined_method           = (known after apply)
      + joined_timestamp        = (known after apply)
      + name                    = (known after apply)
      + service_principal       = "cloudtrail.amazonaws.com"
      + status                  = (known after apply)
    }

  # module.mgmt_resources.aws_organizations_organization.main will be updated in-place
  ~ resource "aws_organizations_organization" "main" {
      ~ aws_service_access_principals = [
          + "cloudtrail.amazonaws.com",
            # (1 unchanged element hidden)
        ]
        id                            = "o-32fecjn1ln"
        # (9 unchanged attributes hidden)
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```