### PR TITLE
mgmt: Create service-linked role for CloudTrail

### DIFF
--- a/accounts/mgmt/resources/main.tf
+++ b/accounts/mgmt/resources/main.tf
@@ -79,6 +79,13 @@ resource "aws_organizations_delegated_administrator" "cloudtrail_sec" {
   account_id        = aws_organizations_account.main["sec"].id
 }
 
+# Normally this role is created automatically when creating an org CloudTrail via the
+# AWS console, but since I'm creating the trail and all of its prerequisites via
+# Terraform, this role must be explicitly created too.
+resource "aws_iam_service_linked_role" "cloudtrail" {
+  aws_service_name = "cloudtrail.amazonaws.com"
+}
+
 ## -------------------------------------------------------------------------------------
 ## IAM IDENTITY CENTER (SSO)
 ## -------------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform plan for **mgmt-dev**:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_iam_service_linked_role.cloudtrail will be created
  + resource "aws_iam_service_linked_role" "cloudtrail" {
      + arn              = (known after apply)
      + aws_service_name = "cloudtrail.amazonaws.com"
      + create_date      = (known after apply)
      + id               = (known after apply)
      + name             = (known after apply)
      + path             = (known after apply)
      + tags_all         = (known after apply)
      + unique_id        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Terraform plan for **mgmt-prod**:

```
Terraform will perform the following actions:

  # module.mgmt_resources.aws_iam_service_linked_role.cloudtrail will be created
  + resource "aws_iam_service_linked_role" "cloudtrail" {
      + arn              = (known after apply)
      + aws_service_name = "cloudtrail.amazonaws.com"
      + create_date      = (known after apply)
      + id               = (known after apply)
      + name             = (known after apply)
      + path             = (known after apply)
      + tags_all         = (known after apply)
      + unique_id        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```