### PR TITLE
sec: Document CloudTrail creation error

### DIFF
--- a/accounts/sec/resources/main.tf
+++ b/accounts/sec/resources/main.tf
@@ -83,6 +83,12 @@ resource "aws_s3_bucket_lifecycle_configuration" "log" {
 # advanced event selector to log both management & data events, especially S3 data
 # events. However, if you do so, make sure to explicitly exclude the CloudTrail log
 # bucket from the event selector, so as not to create an infinite loop.
+# ---
+# There was an "InvalidTrailNameException" error during initial creation of this trail
+# in both dev & prod. In both cases, the problem was fixed by rerunning `terraform
+# apply` to recreate the trail. I suspect an issue in the AWS provider related to org
+# trail creation by a delegated admin, but given that it worked upon recreation, it
+# doesn't seem worth pursuing.
 resource "aws_cloudtrail" "main" {
   name = "main-${var.stage}"
 


### PR DESCRIPTION
Terraform plan in **sec-dev** and **sec-prod**:

```
No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences,
so no changes are needed.
```