### PR TITLE
guardduty: Create service-linked role in mgmt

### DIFF
--- a/capabilities/guardduty/dev/config.tf
+++ b/capabilities/guardduty/dev/config.tf
@@ -373,3 +373,13 @@ provider "aws" {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
   }
 }
+
+## -------------------------------------------------------------------------------------
+## IMPORTS
+## -------------------------------------------------------------------------------------
+
+# Import service-linked role that was created automatically during development
+import {
+  to = module.guardduty_resources.aws_iam_service_linked_role.main
+  id = "arn:aws:iam::590183735431:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"
+}

--- a/capabilities/guardduty/resources/main.tf
+++ b/capabilities/guardduty/resources/main.tf
@@ -1,4 +1,17 @@
 ## -------------------------------------------------------------------------------------
+## SERVICE-LINKED ROLE
+## -------------------------------------------------------------------------------------
+
+# In member accounts, this role is created automatically as part of auto enablement in
+# the org GuardDuty config in the security account, but the role isn't automatically
+# created in the mgmt account, so explicitly create it here.
+resource "aws_iam_service_linked_role" "main" {
+  provider = aws.mgmt_us_east_1
+
+  aws_service_name = "guardduty.amazonaws.com"
+}
+
+## -------------------------------------------------------------------------------------
 ## MODULES
 ## -------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Terraform plan for **guardduty-dev**:

```
Terraform will perform the following actions:

  # module.guardduty_resources.aws_iam_service_linked_role.main will be updated in-place
  # (imported from "arn:aws:iam::590183735431:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty")
  ~ resource "aws_iam_service_linked_role" "main" {
        arn              = "arn:aws:iam::533266992459:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"
        aws_service_name = "guardduty.amazonaws.com"
        create_date      = "2024-07-08T01:03:19Z"
      - description      = "A service-linked role required for Amazon GuardDuty to access your resources. " -> null
        id               = "arn:aws:iam::590183735431:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty"
        name             = "AWSServiceRoleForAmazonGuardDuty"
        path             = "/aws-service-role/guardduty.amazonaws.com/"
        tags             = {}
        tags_all         = {}
        unique_id        = "AROAXYKJQRVF65PGQJ2FJ"
    }

Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
```

Terraform plan for **guardduty-prod**:

```
Terraform will perform the following actions:

  # module.guardduty_resources.aws_iam_service_linked_role.main will be created
  + resource "aws_iam_service_linked_role" "main" {
      + arn              = (known after apply)
      + aws_service_name = "guardduty.amazonaws.com"
      + create_date      = (known after apply)
      + id               = (known after apply)
      + name             = (known after apply)
      + path             = (known after apply)
      + tags_all         = (known after apply)
      + unique_id        = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```