### PR TITLE
account-baseline: Add regional sub-module

### DIFF
--- a/accounts/mgmt/dev/config.tf
+++ b/accounts/mgmt/dev/config.tf
@@ -15,20 +15,6 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
-## PROVIDERS
-## -------------------------------------------------------------------------------------
-
-provider "aws" {
-  # Prevent accidental deployment into the wrong account
-  assume_role {
-    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
-  }
-
-  # Prevent accidental deployment into the wrong region
-  region = "us-east-1"
-}
-
-## -------------------------------------------------------------------------------------
 ## BACKEND
 ## -------------------------------------------------------------------------------------
 
@@ -45,10 +31,173 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
+## PROVIDERS
+## -------------------------------------------------------------------------------------
+
+# Declare AWS providers for each enabled region of the dev management account.
+# Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in a provider
+# block. Thus, a separate provider block is declared for each region, resulting in a lot
+# of duplication. This problem might be alleviated in the future with the release of
+# Terraform Stacks.
+
+provider "aws" {
+  alias  = "ap_northeast_1"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_2"
+  region = "ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_3"
+  region = "ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_south_1"
+  region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_1"
+  region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_2"
+  region = "ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ca_central_1"
+  region = "ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_central_1"
+  region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_north_1"
+  region = "eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_2"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "sa_east_1"
+  region = "sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+}
+
+## -------------------------------------------------------------------------------------
 ## IMPORTS & REMOVED
 ## -------------------------------------------------------------------------------------
 
-# Removed when refactoring CloudTrail into a standalone capability.
+# Removed when refactoring CloudTrail into a standalone capability
 removed {
   from = module.mgmt_resources.aws_organizations_delegated_administrator.cloudtrail_sec
 
@@ -64,7 +213,7 @@ removed {
   }
 }
 
-# Removed when refactoring Terraform state backend into a standalone capability.
+# Removed when refactoring Terraform state backend into a standalone capability
 removed {
   from = module.mgmt_resources.aws_dynamodb_table.tf_state_locks
 

--- a/accounts/mgmt/dev/main.tf
+++ b/accounts/mgmt/dev/main.tf
@@ -10,12 +10,33 @@
 ## -------------------------------------------------------------------------------------
 
 # Child module that declares baseline resources that should be created in us-east-1 of
-# every account in this demo. 
+# each account in each stage, and calls the account-baseline-regional child module for
+# each enabled region.
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
   stage       = "dev"
   account_key = "mgmt"
+
+  providers = {
+    aws.ap_northeast_1 = aws.ap_northeast_1
+    aws.ap_northeast_2 = aws.ap_northeast_2
+    aws.ap_northeast_3 = aws.ap_northeast_3
+    aws.ap_south_1     = aws.ap_south_1
+    aws.ap_southeast_1 = aws.ap_southeast_1
+    aws.ap_southeast_2 = aws.ap_southeast_2
+    aws.ca_central_1   = aws.ca_central_1
+    aws.eu_central_1   = aws.eu_central_1
+    aws.eu_north_1     = aws.eu_north_1
+    aws.eu_west_1      = aws.eu_west_1
+    aws.eu_west_2      = aws.eu_west_2
+    aws.eu_west_3      = aws.eu_west_3
+    aws.sa_east_1      = aws.sa_east_1
+    aws.us_east_1      = aws.us_east_1
+    aws.us_east_2      = aws.us_east_2
+    aws.us_west_1      = aws.us_west_1
+    aws.us_west_2      = aws.us_west_2
+  }
 }
 
 ## -------------------------------------------------------------------------------------
@@ -29,4 +50,8 @@ module "mgmt_resources" {
   source = "../resources"
 
   stage = "dev"
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }

--- a/accounts/mgmt/prod/config.tf
+++ b/accounts/mgmt/prod/config.tf
@@ -15,20 +15,6 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
-## PROVIDERS
-## -------------------------------------------------------------------------------------
-
-provider "aws" {
-  # Prevent accidental deployment into the wrong account
-  assume_role {
-    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
-  }
-
-  # Prevent accidental deployment into the wrong region
-  region = "us-east-1"
-}
-
-## -------------------------------------------------------------------------------------
 ## BACKEND
 ## -------------------------------------------------------------------------------------
 
@@ -45,10 +31,173 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
+## PROVIDERS
+## -------------------------------------------------------------------------------------
+
+# Declare AWS providers for each enabled region of the prod management account.
+# Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in a provider
+# block. Thus, a separate provider block is declared for each region, resulting in a lot
+# of duplication. This problem might be alleviated in the future with the release of
+# Terraform Stacks.
+
+provider "aws" {
+  alias  = "ap_northeast_1"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_2"
+  region = "ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_3"
+  region = "ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_south_1"
+  region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_1"
+  region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_2"
+  region = "ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ca_central_1"
+  region = "ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_central_1"
+  region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_north_1"
+  region = "eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_2"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "sa_east_1"
+  region = "sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+}
+
+## -------------------------------------------------------------------------------------
 ## IMPORTS & REMOVED
 ## -------------------------------------------------------------------------------------
 
-# Removed when refactoring CloudTrail into a standalone capability.
+# Removed when refactoring CloudTrail into a standalone capability
 removed {
   from = module.mgmt_resources.aws_organizations_delegated_administrator.cloudtrail_sec
 
@@ -64,7 +213,7 @@ removed {
   }
 }
 
-# Removed when refactoring Terraform state backend into a standalone capability.
+# Removed when refactoring Terraform state backend into a standalone capability
 removed {
   from = module.mgmt_resources.aws_dynamodb_table.tf_state_locks
 

--- a/accounts/mgmt/prod/main.tf
+++ b/accounts/mgmt/prod/main.tf
@@ -10,12 +10,33 @@
 ## -------------------------------------------------------------------------------------
 
 # Child module that declares baseline resources that should be created in us-east-1 of
-# every account in this demo. 
+# each account in each stage, and calls the account-baseline-regional child module for
+# each enabled region.
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
   stage       = "prod"
   account_key = "mgmt"
+
+  providers = {
+    aws.ap_northeast_1 = aws.ap_northeast_1
+    aws.ap_northeast_2 = aws.ap_northeast_2
+    aws.ap_northeast_3 = aws.ap_northeast_3
+    aws.ap_south_1     = aws.ap_south_1
+    aws.ap_southeast_1 = aws.ap_southeast_1
+    aws.ap_southeast_2 = aws.ap_southeast_2
+    aws.ca_central_1   = aws.ca_central_1
+    aws.eu_central_1   = aws.eu_central_1
+    aws.eu_north_1     = aws.eu_north_1
+    aws.eu_west_1      = aws.eu_west_1
+    aws.eu_west_2      = aws.eu_west_2
+    aws.eu_west_3      = aws.eu_west_3
+    aws.sa_east_1      = aws.sa_east_1
+    aws.us_east_1      = aws.us_east_1
+    aws.us_east_2      = aws.us_east_2
+    aws.us_west_1      = aws.us_west_1
+    aws.us_west_2      = aws.us_west_2
+  }
 }
 
 ## -------------------------------------------------------------------------------------
@@ -29,4 +50,8 @@ module "mgmt_resources" {
   source = "../resources"
 
   stage = "prod"
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }

--- a/accounts/sec/dev/config.tf
+++ b/accounts/sec/dev/config.tf
@@ -15,20 +15,6 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
-## PROVIDERS
-## -------------------------------------------------------------------------------------
-
-provider "aws" {
-  # Prevent accidental deployment into the wrong account
-  assume_role {
-    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
-  }
-
-  # Prevent accidental deployment into the wrong region
-  region = "us-east-1"
-}
-
-## -------------------------------------------------------------------------------------
 ## BACKEND
 ## -------------------------------------------------------------------------------------
 
@@ -41,6 +27,169 @@ terraform {
     assume_role = {
       role_arn = "arn:aws:iam::533266992459:role/tf-state-manager-dev"
     }
+  }
+}
+
+## -------------------------------------------------------------------------------------
+## PROVIDERS
+## -------------------------------------------------------------------------------------
+
+# Declare AWS providers for each enabled region of the dev security account.
+# Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in a provider
+# block. Thus, a separate provider block is declared for each region, resulting in a lot
+# of duplication. This problem might be alleviated in the future with the release of
+# Terraform Stacks.
+
+provider "aws" {
+  alias  = "ap_northeast_1"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_2"
+  region = "ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_3"
+  region = "ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_south_1"
+  region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_1"
+  region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_2"
+  region = "ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "ca_central_1"
+  region = "ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_central_1"
+  region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_north_1"
+  region = "eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_2"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "sa_east_1"
+  region = "sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
   }
 }
 

--- a/accounts/sec/dev/main.tf
+++ b/accounts/sec/dev/main.tf
@@ -10,12 +10,33 @@
 ## -------------------------------------------------------------------------------------
 
 # Child module that declares baseline resources that should be created in us-east-1 of
-# every account in this demo. 
+# each account in each stage, and calls the account-baseline-regional child module for
+# each enabled region.
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
   stage       = "dev"
   account_key = "sec"
+
+  providers = {
+    aws.ap_northeast_1 = aws.ap_northeast_1
+    aws.ap_northeast_2 = aws.ap_northeast_2
+    aws.ap_northeast_3 = aws.ap_northeast_3
+    aws.ap_south_1     = aws.ap_south_1
+    aws.ap_southeast_1 = aws.ap_southeast_1
+    aws.ap_southeast_2 = aws.ap_southeast_2
+    aws.ca_central_1   = aws.ca_central_1
+    aws.eu_central_1   = aws.eu_central_1
+    aws.eu_north_1     = aws.eu_north_1
+    aws.eu_west_1      = aws.eu_west_1
+    aws.eu_west_2      = aws.eu_west_2
+    aws.eu_west_3      = aws.eu_west_3
+    aws.sa_east_1      = aws.sa_east_1
+    aws.us_east_1      = aws.us_east_1
+    aws.us_east_2      = aws.us_east_2
+    aws.us_west_1      = aws.us_west_1
+    aws.us_west_2      = aws.us_west_2
+  }
 }
 
 ## -------------------------------------------------------------------------------------
@@ -30,4 +51,8 @@ module "sec_resources" {
 
   stage           = "dev"
   mgmt_account_id = "533266992459"
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }

--- a/accounts/sec/prod/config.tf
+++ b/accounts/sec/prod/config.tf
@@ -15,20 +15,6 @@ terraform {
 }
 
 ## -------------------------------------------------------------------------------------
-## PROVIDERS
-## -------------------------------------------------------------------------------------
-
-provider "aws" {
-  # Prevent accidental deployment into the wrong account
-  assume_role {
-    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
-  }
-
-  # Prevent accidental deployment into the wrong region
-  region = "us-east-1"
-}
-
-## -------------------------------------------------------------------------------------
 ## BACKEND
 ## -------------------------------------------------------------------------------------
 
@@ -41,6 +27,169 @@ terraform {
     assume_role = {
       role_arn = "arn:aws:iam::339712815005:role/tf-state-manager-prod"
     }
+  }
+}
+
+## -------------------------------------------------------------------------------------
+## PROVIDERS
+## -------------------------------------------------------------------------------------
+
+# Declare AWS providers for each enabled region of the prod security account.
+# Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in a provider
+# block. Thus, a separate provider block is declared for each region, resulting in a lot
+# of duplication. This problem might be alleviated in the future with the release of
+# Terraform Stacks.
+
+provider "aws" {
+  alias  = "ap_northeast_1"
+  region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_2"
+  region = "ap-northeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_northeast_3"
+  region = "ap-northeast-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_south_1"
+  region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_1"
+  region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ap_southeast_2"
+  region = "ap-southeast-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "ca_central_1"
+  region = "ca-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_central_1"
+  region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_north_1"
+  region = "eu-north-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_1"
+  region = "eu-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_2"
+  region = "eu-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "eu_west_3"
+  region = "eu-west-3"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "sa_east_1"
+  region = "sa-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_1"
+  region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+}
+
+provider "aws" {
+  alias  = "us_west_2"
+  region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
   }
 }
 

--- a/accounts/sec/prod/main.tf
+++ b/accounts/sec/prod/main.tf
@@ -10,12 +10,33 @@
 ## -------------------------------------------------------------------------------------
 
 # Child module that declares baseline resources that should be created in us-east-1 of
-# every account in this demo. 
+# each account in each stage, and calls the account-baseline-regional child module for
+# each enabled region.
 module "account_baseline" {
   source = "../../../modules/account-baseline"
 
   stage       = "prod"
   account_key = "sec"
+
+  providers = {
+    aws.ap_northeast_1 = aws.ap_northeast_1
+    aws.ap_northeast_2 = aws.ap_northeast_2
+    aws.ap_northeast_3 = aws.ap_northeast_3
+    aws.ap_south_1     = aws.ap_south_1
+    aws.ap_southeast_1 = aws.ap_southeast_1
+    aws.ap_southeast_2 = aws.ap_southeast_2
+    aws.ca_central_1   = aws.ca_central_1
+    aws.eu_central_1   = aws.eu_central_1
+    aws.eu_north_1     = aws.eu_north_1
+    aws.eu_west_1      = aws.eu_west_1
+    aws.eu_west_2      = aws.eu_west_2
+    aws.eu_west_3      = aws.eu_west_3
+    aws.sa_east_1      = aws.sa_east_1
+    aws.us_east_1      = aws.us_east_1
+    aws.us_east_2      = aws.us_east_2
+    aws.us_west_1      = aws.us_west_1
+    aws.us_west_2      = aws.us_west_2
+  }
 }
 
 ## -------------------------------------------------------------------------------------
@@ -30,4 +51,8 @@ module "sec_resources" {
 
   stage           = "prod"
   mgmt_account_id = "339712815005"
+
+  providers = {
+    aws = aws.us_east_1
+  }
 }

--- a/capabilities/guardduty/dev/config.tf
+++ b/capabilities/guardduty/dev/config.tf
@@ -34,6 +34,12 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+# Declare AWS providers for each enabled region of the dev management & security
+# accounts. Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in
+# a provider block. Thus, a separate provider block is declared for each region of each
+# account, resulting in a lot of duplication. This problem might be alleviated in the
+# future with the release of Terraform Stacks.
+
 # ap-northeast-1
 
 provider "aws" {

--- a/capabilities/guardduty/prod/config.tf
+++ b/capabilities/guardduty/prod/config.tf
@@ -34,6 +34,12 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+# Declare AWS providers for each enabled region of the prod management & security
+# accounts. Unfortunately, as of Terraform v1.7, it's not possible to use `for_each` in
+# a provider block. Thus, a separate provider block is declared for each region of each
+# account, resulting in a lot of duplication. This problem might be alleviated in the
+# future with the release of Terraform Stacks.
+
 # ap-northeast-1
 
 provider "aws" {

--- a/modules/account-baseline/README.md
+++ b/modules/account-baseline/README.md
@@ -1,3 +1,3 @@
 # account-baseline
 
-Terraform child module that declares a baseline set of resources that's created in every account in this demo. Called by the root module for each account-specific Terraform config in **accounts/**.
+Terraform child module that declares baseline resources that should be created in us-east-1 of each account in each stage, and calls the **account-baseline-regional** child module for each enabled region. Called by the root module for each account-specific Terraform config in **accounts/**.

--- a/modules/account-baseline/config.tf
+++ b/modules/account-baseline/config.tf
@@ -10,6 +10,25 @@ terraform {
   required_providers {
     aws = {
       version = "~> 5.39"
+      configuration_aliases = [
+        aws.ap_northeast_1,
+        aws.ap_northeast_2,
+        aws.ap_northeast_3,
+        aws.ap_south_1,
+        aws.ap_southeast_1,
+        aws.ap_southeast_2,
+        aws.ca_central_1,
+        aws.eu_central_1,
+        aws.eu_north_1,
+        aws.eu_west_1,
+        aws.eu_west_2,
+        aws.eu_west_3,
+        aws.sa_east_1,
+        aws.us_east_1,
+        aws.us_east_2,
+        aws.us_west_1,
+        aws.us_west_2,
+      ]
     }
   }
 }

--- a/modules/account-baseline/main.tf
+++ b/modules/account-baseline/main.tf
@@ -2,8 +2,8 @@
 ## NOTICE
 ## -------------------------------------------------------------------------------------
 
-# Resources declared directly in this file will be created in us-east-1 of every account
-# in every stage, but not any other region.
+# Resources declared directly in this file will be created in us-east-1 of each account
+# in each stage, but not any other region.
 
 ## -------------------------------------------------------------------------------------
 ## ACCOUNT ALIAS
@@ -13,6 +13,8 @@
 # and include "demo-" to reduce chance of naming collision with other DevShrekOps
 # projects.
 resource "aws_iam_account_alias" "main" {
+  provider = aws.us_east_1
+
   account_alias = "devshrekops-demo-${var.account_key}-${var.stage}"
 }
 
@@ -22,8 +24,191 @@ resource "aws_iam_account_alias" "main" {
 
 # Drastically reduce the chances of an S3 bucket being accidentally opened to the public
 resource "aws_s3_account_public_access_block" "main" {
+  provider = aws.us_east_1
+
   block_public_acls       = true
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
+}
+
+## -------------------------------------------------------------------------------------
+## REGIONAL MODULE
+## -------------------------------------------------------------------------------------
+
+# Child module that declares baseline resources that should be created in each enabled
+# region of each account in each stage. Unfortunately, as of Terraform v1.7, it's not
+# possible to use `for_each` to call the same module multiple times with different
+# providers. Thus, a separate module block is declared for each region, resulting in a
+# lot of duplication. This problem might be alleviated in the future with the release of
+# Terraform Stacks.
+
+module "ap_northeast_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_northeast_1
+  }
+}
+
+module "ap_northeast_2" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_northeast_2
+  }
+}
+
+module "ap_northeast_3" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_northeast_3
+  }
+}
+
+module "ap_south_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_south_1
+  }
+}
+
+module "ap_southeast_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_southeast_1
+  }
+}
+
+module "ap_southeast_2" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ap_southeast_2
+  }
+}
+
+module "ca_central_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.ca_central_1
+  }
+}
+
+module "eu_central_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.eu_central_1
+  }
+}
+
+module "eu_north_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.eu_north_1
+  }
+}
+
+module "eu_west_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.eu_west_1
+  }
+}
+
+module "eu_west_2" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.eu_west_2
+  }
+}
+
+module "eu_west_3" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.eu_west_3
+  }
+}
+
+module "sa_east_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.sa_east_1
+  }
+}
+
+module "us_east_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.us_east_1
+  }
+}
+
+module "us_east_2" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.us_east_2
+  }
+}
+
+module "us_west_1" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.us_west_1
+  }
+}
+
+module "us_west_2" {
+  source = "./regional"
+
+  stage = var.stage
+
+  providers = {
+    aws = aws.us_west_2
+  }
 }

--- a/modules/account-baseline/outputs.tf
+++ b/modules/account-baseline/outputs.tf
@@ -2,3 +2,26 @@ output "account_alias" {
   description = "Globally unique alias of this account."
   value       = aws_iam_account_alias.main.account_alias
 }
+
+output "regional" {
+  description = "All outputs from the regional module."
+  value = {
+    "ap-northeast-1" : module.ap_northeast_1,
+    "ap-northeast-2" : module.ap_northeast_2,
+    "ap-northeast-3" : module.ap_northeast_3,
+    "ap-south-1" : module.ap_south_1,
+    "ap-southeast-1" : module.ap_southeast_1,
+    "ap-southeast-2" : module.ap_southeast_2,
+    "ca-central-1" : module.ca_central_1,
+    "eu-central-1" : module.eu_central_1,
+    "eu-north-1" : module.eu_north_1,
+    "eu-west-1" : module.eu_west_1,
+    "eu-west-2" : module.eu_west_2,
+    "eu-west-3" : module.eu_west_3,
+    "sa-east-1" : module.sa_east_1,
+    "us-east-1" : module.us_east_1,
+    "us-east-2" : module.us_east_2,
+    "us-west-1" : module.us_west_1,
+    "us-west-2" : module.us_west_2,
+  }
+}

--- a/modules/account-baseline/regional/README.md
+++ b/modules/account-baseline/regional/README.md
@@ -1,0 +1,3 @@
+# account-baseline-regional
+
+Terraform child module that declares baseline resources that should be created in each enabled region of each account in each stage. Called once for each enabled region by the **account-baseline** child module.

--- a/modules/account-baseline/regional/config.tf
+++ b/modules/account-baseline/regional/config.tf
@@ -1,0 +1,16 @@
+# See README.md in this repo's root directory for commentary on this file.
+
+## -------------------------------------------------------------------------------------
+## VERSIONS
+## -------------------------------------------------------------------------------------
+
+terraform {
+  required_version = "~> 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.39"
+    }
+  }
+}

--- a/modules/account-baseline/regional/main.tf
+++ b/modules/account-baseline/regional/main.tf
@@ -1,0 +1,6 @@
+## -------------------------------------------------------------------------------------
+## NOTICE
+## -------------------------------------------------------------------------------------
+
+# Resources declared directly in this file will be created in each enabled region of
+# each account in each stage.

--- a/modules/account-baseline/regional/outputs.tf
+++ b/modules/account-baseline/regional/outputs.tf
@@ -1,0 +1,1 @@
+# Placeholder

--- a/modules/account-baseline/regional/variables.tf
+++ b/modules/account-baseline/regional/variables.tf
@@ -1,0 +1,9 @@
+## -------------------------------------------------------------------------------------
+## REQUIRED INPUT VARIABLES
+## -------------------------------------------------------------------------------------
+
+variable "stage" {
+  description = "Deployment stage (e.g., dev or prod)."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
Terraform plan isn't available for **mgmt-dev** & **sec-dev** because changes to it were applied iteratively during development.

Terraform plan for **mgmt-prod**:

```
Changes to Outputs:
  ~ account_baseline = {
      + regional      = {
          + ap-northeast-1 = {}
          + ap-northeast-2 = {}
          + ap-northeast-3 = {}
          + ap-south-1     = {}
          + ap-southeast-1 = {}
          + ap-southeast-2 = {}
          + ca-central-1   = {}
          + eu-central-1   = {}
          + eu-north-1     = {}
          + eu-west-1      = {}
          + eu-west-2      = {}
          + eu-west-3      = {}
          + sa-east-1      = {}
          + us-east-1      = {}
          + us-east-2      = {}
          + us-west-1      = {}
          + us-west-2      = {}
        }
        # (1 unchanged attribute hidden)
    }

You can apply this plan to save these new output values to the Terraform state, without changing any
real infrastructure.
```

Terraform plan for **sec-prod**:

```
Changes to Outputs:
  ~ account_baseline = {
      + regional      = {
          + ap-northeast-1 = {}
          + ap-northeast-2 = {}
          + ap-northeast-3 = {}
          + ap-south-1     = {}
          + ap-southeast-1 = {}
          + ap-southeast-2 = {}
          + ca-central-1   = {}
          + eu-central-1   = {}
          + eu-north-1     = {}
          + eu-west-1      = {}
          + eu-west-2      = {}
          + eu-west-3      = {}
          + sa-east-1      = {}
          + us-east-1      = {}
          + us-east-2      = {}
          + us-west-1      = {}
          + us-west-2      = {}
        }
        # (1 unchanged attribute hidden)
    }

You can apply this plan to save these new output values to the Terraform state, without changing any
real infrastructure.
```