### PR TITLE
org: Enable trusted access for AWS Config

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -27,6 +27,7 @@ resource "aws_organizations_organization" "main" {
   # Integrate the org with other services (e.g., IAM Identity Center)
   aws_service_access_principals = [
     "cloudtrail.amazonaws.com",
+    "config.amazonaws.com", # Required for multi-account, multi-region data aggregation
     "guardduty.amazonaws.com",
     "malware-protection.guardduty.amazonaws.com",
     "sso.amazonaws.com", # IAM Identity Center


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_organization.main will be updated in-place
  ~ resource "aws_organizations_organization" "main" {
      ~ aws_service_access_principals = [
          + "config.amazonaws.com",
            # (4 unchanged elements hidden)
        ]
        id                            = "o-32fecjn1ln"
        # (10 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The same changes were already applied to **org-dev** during development.