### PR TITLE
config: Register sec account as delegated admin

### DIFF
--- a/capabilities/config/resources/main.tf
+++ b/capabilities/config/resources/main.tf
@@ -5,3 +5,30 @@
 # Resources declared directly in this file will only be created in us-east-1 of each
 # stage's management or security account (depending on provider), not any other account
 # nor region.
+
+## -------------------------------------------------------------------------------------
+## COMMON DATA SOURCES & LOCAL VALUES
+## -------------------------------------------------------------------------------------
+
+# Fetch the account ID of the security AWS account
+data "aws_caller_identity" "sec" {
+  provider = aws.sec_us_east_1
+}
+
+# Store as local value for easier referencing
+locals {
+  sec_account_id = data.aws_caller_identity.sec.account_id
+}
+
+## -------------------------------------------------------------------------------------
+## DELEGATED CONFIG ADMIN
+## -------------------------------------------------------------------------------------
+
+# Enable the security account to create a Config multi-account, multi-region data
+# aggregator.
+resource "aws_organizations_delegated_administrator" "main" {
+  provider = aws.mgmt_us_east_1
+
+  service_principal = "config.amazonaws.com"
+  account_id        = local.sec_account_id
+}


### PR DESCRIPTION
Terraform plan for **config-prod**:

```
Terraform will perform the following actions:

  # module.config_resources.aws_organizations_delegated_administrator.main will be created
  + resource "aws_organizations_delegated_administrator" "main" {
      + account_id              = "590183735431"
      + arn                     = (known after apply)
      + delegation_enabled_date = (known after apply)
      + email                   = (known after apply)
      + id                      = (known after apply)
      + joined_method           = (known after apply)
      + joined_timestamp        = (known after apply)
      + name                    = (known after apply)
      + service_principal       = "config.amazonaws.com"
      + status                  = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

The same changes were already applied to **config-dev** during development.