### PR TITLE
config: Create S3 bucket for logs

### DIFF
--- a/capabilities/config/resources/main.tf
+++ b/capabilities/config/resources/main.tf
@@ -15,8 +15,14 @@ data "aws_caller_identity" "sec" {
   provider = aws.sec_us_east_1
 }
 
-# Store as local value for easier referencing
+# Fetch the org ID from the management AWS account
+data "aws_organizations_organization" "main" {
+  provider = aws.mgmt_us_east_1
+}
+
+# Store as local values for easier referencing
 locals {
+  org_id         = data.aws_organizations_organization.main.id
   sec_account_id = data.aws_caller_identity.sec.account_id
 }
 
@@ -31,4 +37,108 @@ resource "aws_organizations_delegated_administrator" "main" {
 
   service_principal = "config.amazonaws.com"
   account_id        = local.sec_account_id
+}
+
+## -------------------------------------------------------------------------------------
+## S3 BUCKET FOR CONFIG LOGS
+## -------------------------------------------------------------------------------------
+
+# A separate bucket is created for each log type to avoid complications when supporting
+# a bunch of log types. When a single bucket is used for lots of log types that each
+# require their own policy statements, the bucket policy can become difficult to
+# understand and there's a risk of running into a policy size limit. Using a single
+# bucket for multiple log types can also make it trickier to configure event
+# notifications in some cases, since wildcards aren't supported.
+module "baseline_s3_bucket" {
+  # This module declares an S3 bucket with a baseline configuration that should be used
+  # for all buckets in this git repo unless there's a specific reason not to.
+  source = "../../../modules/baseline-s3-bucket"
+
+  providers = {
+    aws = aws.sec_us_east_1
+  }
+
+  stage = var.stage
+  scope = "config-logs"
+
+  # The bucket policy will consist of a policy document that's the same across all
+  # buckets combined with the policy document referenced below that's specific to
+  # Config.
+  extra_bucket_policy_documents = [data.aws_iam_policy_document.main.json]
+}
+
+# This policy document is passed into the baseline_s3_bucket module (via the
+# extra_bucket_policy_documents variable) which creates the bucket policy for the Config
+# logs bucket by combining this policy document (which is specific to Config) with
+# another policy document that's the same across all buckets.
+data "aws_iam_policy_document" "main" {
+  statement {
+    sid    = "AllowAccessByConfigSvcPrincipal"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["config.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:ListBucket",
+      "s3:PutObject",
+    ]
+
+    # Unlike the bucket_arn output, unsafe_bucket_arn isn't configured with an explicit
+    # dependency on the bucket policy, thus allowing it to be referenced in this policy.
+    # Also, the AWS docs provide an example policy that restricts the resources for
+    # s3:PutObject to granular paths that include the source account ID, but I don't
+    # think such granularity adds any value, especially in this case, since the bucket
+    # will need to receive Config logs from all accounts in the org, and thus the source
+    # account ID would need to be a wildcard anyway.
+    resources = [
+      module.baseline_s3_bucket.unsafe_bucket_arn,
+      "${module.baseline_s3_bucket.unsafe_bucket_arn}/*",
+    ]
+
+    # The AWS docs provide an example policy that includes two conditions, one to
+    # enforce that the bucket owner has full control over objects created by the Config
+    # service principal, and another to restrict which AWS account(s) the Config service
+    # principal can write to this bucket from. The first condition isn't necessary here,
+    # since ACLs are disabled by baseline_s3_bucket, meaning the bucket owner
+    # automatically owns all objects that are created in it, even ones created by
+    # service principals. The second condition is important because it prevents a
+    # confused deputy attack in which a 3rd party could configure Config in their AWS
+    # account to write logs to this bucket, but rather than restrict access by specific
+    # AWS account IDs (which would require updating this policy each time a new account
+    # was created in the org, and would eventually run into a max bucket policy size
+    # limit), access is restricted by org ID so that the Config service principal can
+    # write to this bucket from any current & future account in the org.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceOrgID"
+      values   = [local.org_id]
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "main" {
+  provider = aws.sec_us_east_1
+
+  bucket = module.baseline_s3_bucket.bucket_id
+
+  rule {
+    id = "delete-old-files-${var.stage}"
+
+    status = "Enabled"
+
+    # Apply the rule to all objects in the bucket
+    filter {}
+
+    # Since this is just a demo, minimize costs by deleting files after one day. In a
+    # real deployment, the expiration should be much higher, at least in prod. Even if
+    # you're ingesting log files into a SIEM, it's probably worth keeping the log files
+    # around in S3 as a backup for at least a couple of weeks.
+    expiration {
+      days = 1
+    }
+  }
 }

--- a/capabilities/config/resources/outputs.tf
+++ b/capabilities/config/resources/outputs.tf
@@ -1,1 +1,4 @@
-# Placeholder
+output "baseline_s3_bucket_outputs" {
+  description = "All outputs from the baseline_s3_bucket module."
+  value       = module.baseline_s3_bucket
+}


### PR DESCRIPTION
Terraform plan for **config-prod**:

```
Terraform will perform the following actions:

  # module.config_resources.data.aws_iam_policy_document.main will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "main" {
      + id            = (known after apply)
      + json          = (known after apply)
      + minified_json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetBucketAcl",
              + "s3:ListBucket",
              + "s3:PutObject",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
              + (known after apply),
            ]
          + sid       = "AllowAccessByConfigSvcPrincipal"

          + condition {
              + test     = "StringEquals"
              + values   = [
                  + "o-32fecjn1ln",
                ]
              + variable = "aws:SourceOrgID"
            }

          + principals {
              + identifiers = [
                  + "config.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.config_resources.aws_s3_bucket_lifecycle_configuration.main will be created
  + resource "aws_s3_bucket_lifecycle_configuration" "main" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + id     = "delete-old-files-prod"
          + status = "Enabled"

          + expiration {
              + days                         = 1
              + expired_object_delete_marker = (known after apply)
            }

          + filter {
            }
        }
    }

  # module.config_resources.module.baseline_s3_bucket.data.aws_iam_policy_document.baseline_bucket_policy will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "baseline_bucket_policy" {
      + id                      = (known after apply)
      + json                    = (known after apply)
      + minified_json           = (known after apply)
      + source_policy_documents = [
          + (known after apply),
        ]

      + statement {
          + actions   = [
              + "s3:*",
            ]
          + effect    = "Deny"
          + resources = [
              + (known after apply),
              + (known after apply),
            ]
          + sid       = "RequireLatestTLS"

          + condition {
              + test     = "NumericLessThan"
              + values   = [
                  + "1.3",
                ]
              + variable = "s3:TlsVersion"
            }

          + principals {
              + identifiers = [
                  + "*",
                ]
              + type        = "*"
            }
        }
    }

  # module.config_resources.module.baseline_s3_bucket.aws_s3_bucket.main will be created
  + resource "aws_s3_bucket" "main" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "devshrekops-demo-config-logs-prod"
      + bucket_domain_name          = (known after apply)
      + bucket_prefix               = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)
    }

  # module.config_resources.module.baseline_s3_bucket.aws_s3_bucket_ownership_controls.main will be created
  + resource "aws_s3_bucket_ownership_controls" "main" {
      + bucket = (known after apply)
      + id     = (known after apply)

      + rule {
          + object_ownership = "BucketOwnerEnforced"
        }
    }

  # module.config_resources.module.baseline_s3_bucket.aws_s3_bucket_policy.main will be created
  + resource "aws_s3_bucket_policy" "main" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.config_resources.module.baseline_s3_bucket.aws_s3_bucket_public_access_block.main will be created
  + resource "aws_s3_bucket_public_access_block" "main" {
      + block_public_acls       = true
      + block_public_policy     = true
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = true
      + restrict_public_buckets = true
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ config_resources = {
      + baseline_s3_bucket_outputs = {
          + bucket_arn        = (known after apply)
          + bucket_id         = (known after apply)
          + unsafe_bucket_arn = (known after apply)
        }
    }
```

The same changes were already applied to **config-dev** during development.