### PR TITLE
account-baseline: Enable Config in all regions

### DIFF
--- a/capabilities/config/README.md
+++ b/capabilities/config/README.md
@@ -10,3 +10,5 @@ Terraform configs for registering each stage's security account as a delegated C
 ## External Dependencies
 
 These modules can't be applied until after trusted access is enabled between Organizations and Config in the management account, which is configured in **org-resources**.
+
+For the multi-account, multi-region data aggregator to aggregate logs from each region of each account, a service-linked role for Config must be created in each account, a Config recorder & delivery channel must be created in each region of each account, and each Config recorder must be enabled. These resources are declared in **account-baseline** and **account-baseline-regional**. I would've preferred to declare them here instead so that they'd be declared side-by-side with other Config-related resources, but because they need to be created in each account (or each region of each account), it's more practical to declare them in the **account-baseline** and **account-baseline-regional** modules. Otherwise, this module would have to be updated with new AWS providers each time a new account was created in the org.

--- a/capabilities/config/dev/README.md
+++ b/capabilities/config/dev/README.md
@@ -5,3 +5,5 @@ Terraform root module for registering the dev security account as a delegated Co
 ## External Dependencies
 
 This module can't be applied until after trusted access is enabled between Organizations and Config in the management account, which is configured in **org-resources**.
+
+For the multi-account, multi-region data aggregator to aggregate logs from each region of each account, a service-linked role for Config must be created in each account, a Config recorder & delivery channel must be created in each region of each account, and each Config recorder must be enabled. These resources are declared in **account-baseline** and **account-baseline-regional**. I would've preferred to declare them here instead so that they'd be declared side-by-side with other Config-related resources, but because they need to be created in each account (or each region of each account), it's more practical to declare them in the **account-baseline** and **account-baseline-regional** modules. Otherwise, this module would have to be updated with new AWS providers each time a new account was created in the org.

--- a/capabilities/config/prod/README.md
+++ b/capabilities/config/prod/README.md
@@ -5,3 +5,5 @@ Terraform root module for registering the prod security account as a delegated C
 ## External Dependencies
 
 This module can't be applied until after trusted access is enabled between Organizations and Config in the management account, which is configured in **org-resources**.
+
+For the multi-account, multi-region data aggregator to aggregate logs from each region of each account, a service-linked role for Config must be created in each account, a Config recorder & delivery channel must be created in each region of each account, and each Config recorder must be enabled. These resources are declared in **account-baseline** and **account-baseline-regional**. I would've preferred to declare them here instead so that they'd be declared side-by-side with other Config-related resources, but because they need to be created in each account (or each region of each account), it's more practical to declare them in the **account-baseline** and **account-baseline-regional** modules. Otherwise, this module would have to be updated with new AWS providers each time a new account was created in the org.

--- a/capabilities/config/resources/README.md
+++ b/capabilities/config/resources/README.md
@@ -5,3 +5,5 @@ Terraform child module that declares all Config resources that should be created
 ## External Dependencies
 
 This module can't be applied until after trusted access is enabled between Organizations and Config in the management account, which is configured in **org-resources**.
+
+For the multi-account, multi-region data aggregator to aggregate logs from each region of each account, a service-linked role for Config must be created in each account, a Config recorder & delivery channel must be created in each region of each account, and each Config recorder must be enabled. These resources are declared in **account-baseline** and **account-baseline-regional**. I would've preferred to declare them here instead so that they'd be declared side-by-side with other Config-related resources, but because they need to be created in each account (or each region of each account), it's more practical to declare them in the **account-baseline** and **account-baseline-regional** modules. Otherwise, this module would have to be updated with new AWS providers each time a new account was created in the org.

--- a/capabilities/config/resources/main.tf
+++ b/capabilities/config/resources/main.tf
@@ -59,6 +59,11 @@ module "baseline_s3_bucket" {
   }
 
   stage = var.stage
+
+  # If the scope of this bucket is ever changed (or if any other change is ever made
+  # that results in this bucket being renamed), then the hardcoded reference to this
+  # bucket name in the Config delivery channel resource declaration in the
+  # account-baseline-regional module must be updated accordingly.
   scope = "config-logs"
 
   # The bucket policy will consist of a policy document that's the same across all

--- a/modules/account-baseline/README.md
+++ b/modules/account-baseline/README.md
@@ -1,3 +1,7 @@
 # account-baseline
 
 Terraform child module that declares baseline resources that should be created in us-east-1 of each account in each stage, and calls the **account-baseline-regional** child module for each enabled region. Called by the root module for each account-specific Terraform config in **accounts/**.
+
+## External Dependencies
+
+This module can't be applied until after an S3 bucket for storing Config logs is created in the current stage's security account, which is declared in the **config** capability.

--- a/modules/account-baseline/main.tf
+++ b/modules/account-baseline/main.tf
@@ -33,6 +33,22 @@ resource "aws_s3_account_public_access_block" "main" {
 }
 
 ## -------------------------------------------------------------------------------------
+## SERVICE-LINKED ROLE FOR CONFIG
+## -------------------------------------------------------------------------------------
+
+# Used by the Config recorder that's created in each region via the regional module. I
+# would've preferred to declare it in the standalone config capability so that it'd be
+# declared side-by-side with other Config-related resources, but because it needs to be
+# created in each account, it's more practical to declare it here instead. Otherwise,
+# the config capability modules would have to be updated with new AWS providers each
+# time a new account was created in the org.
+resource "aws_iam_service_linked_role" "config" {
+  provider = aws.us_east_1
+
+  aws_service_name = "config.amazonaws.com"
+}
+
+## -------------------------------------------------------------------------------------
 ## REGIONAL MODULE
 ## -------------------------------------------------------------------------------------
 
@@ -46,7 +62,8 @@ resource "aws_s3_account_public_access_block" "main" {
 module "ap_northeast_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_northeast_1
@@ -56,7 +73,8 @@ module "ap_northeast_1" {
 module "ap_northeast_2" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_northeast_2
@@ -66,7 +84,8 @@ module "ap_northeast_2" {
 module "ap_northeast_3" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_northeast_3
@@ -76,7 +95,8 @@ module "ap_northeast_3" {
 module "ap_south_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_south_1
@@ -86,7 +106,8 @@ module "ap_south_1" {
 module "ap_southeast_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_southeast_1
@@ -96,7 +117,8 @@ module "ap_southeast_1" {
 module "ap_southeast_2" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ap_southeast_2
@@ -106,7 +128,8 @@ module "ap_southeast_2" {
 module "ca_central_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.ca_central_1
@@ -116,7 +139,8 @@ module "ca_central_1" {
 module "eu_central_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.eu_central_1
@@ -126,7 +150,8 @@ module "eu_central_1" {
 module "eu_north_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.eu_north_1
@@ -136,7 +161,8 @@ module "eu_north_1" {
 module "eu_west_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.eu_west_1
@@ -146,7 +172,8 @@ module "eu_west_1" {
 module "eu_west_2" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.eu_west_2
@@ -156,7 +183,8 @@ module "eu_west_2" {
 module "eu_west_3" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.eu_west_3
@@ -166,7 +194,8 @@ module "eu_west_3" {
 module "sa_east_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.sa_east_1
@@ -176,7 +205,8 @@ module "sa_east_1" {
 module "us_east_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.us_east_1
@@ -186,7 +216,8 @@ module "us_east_1" {
 module "us_east_2" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.us_east_2
@@ -196,7 +227,8 @@ module "us_east_2" {
 module "us_west_1" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.us_west_1
@@ -206,7 +238,8 @@ module "us_west_1" {
 module "us_west_2" {
   source = "./regional"
 
-  stage = var.stage
+  stage               = var.stage
+  config_svc_role_arn = aws_iam_service_linked_role.config.arn
 
   providers = {
     aws = aws.us_west_2

--- a/modules/account-baseline/regional/README.md
+++ b/modules/account-baseline/regional/README.md
@@ -1,3 +1,7 @@
 # account-baseline-regional
 
 Terraform child module that declares baseline resources that should be created in each enabled region of each account in each stage. Called once for each enabled region by the **account-baseline** child module.
+
+## External Dependencies
+
+This module can't be applied until after an S3 bucket for storing Config logs is created in the current stage's security account, which is declared in the **config** capability.

--- a/modules/account-baseline/regional/main.tf
+++ b/modules/account-baseline/regional/main.tf
@@ -4,3 +4,123 @@
 
 # Resources declared directly in this file will be created in each enabled region of
 # each account in each stage.
+
+## -------------------------------------------------------------------------------------
+## COMMON DATA SOURCES & LOCAL VALUES
+## -------------------------------------------------------------------------------------
+
+# Fetch the current region
+data "aws_region" "main" {}
+
+# Store as local value for easier referencing
+locals {
+  region = data.aws_region.main.name
+}
+
+## -------------------------------------------------------------------------------------
+## CONFIG RECORDER & DELIVERY CHANNEL
+## -------------------------------------------------------------------------------------
+
+# I would've preferred to declare these resources in the standalone config capability so
+# that they're declared side-by-side with other Config-related resources, but because
+# they need to be created in each account, it's more practical to declare them here
+# instead. Otherwise, the config capability modules would have to be updated with new
+# AWS providers each time a new account was created in the org.
+
+locals {
+  # Reduce costs by excluding resources that are created by default in all accounts but
+  # which aren't being used in this demo. In a real deployment, it's probably best to
+  # record all supported resources and eat the extra cost, at least in prod.
+  config_resource_types_to_exclude_in_all_regions = [
+    "AWS::AppConfig::DeploymentStrategy",
+    "AWS::Athena::WorkGroup",
+    "AWS::Cassandra::Keyspace",
+    "AWS::CodeDeploy::DeploymentConfig",
+    "AWS::ECS::CapacityProvider",
+  ]
+
+  # In regions other than us-east-1, in addition to excluding the resources above, also
+  # exclude global resources so that they're only recorded a single time per account.
+  config_resources_to_exclude_in_secondary_regions = concat(
+    local.config_resource_types_to_exclude_in_all_regions,
+    [
+      "AWS::IAM::Group",
+      "AWS::IAM::InstanceProfile",
+      "AWS::IAM::Policy",
+      "AWS::IAM::Role",
+      "AWS::IAM::SAMLProvider",
+      "AWS::IAM::User",
+      "AWS::S3::AccountPublicAccessBlock",
+    ]
+  )
+}
+
+resource "aws_config_configuration_recorder" "main" {
+  name     = "main-${var.stage}"
+  role_arn = var.config_svc_role_arn
+
+  recording_group {
+    all_supported = false
+
+    recording_strategy {
+      use_only = "EXCLUSION_BY_RESOURCE_TYPES"
+    }
+
+    exclusion_by_resource_types {
+      resource_types = (
+        local.region == "us-east-1" ?
+        local.config_resource_types_to_exclude_in_all_regions :
+        local.config_resources_to_exclude_in_secondary_regions
+      )
+    }
+  }
+
+  recording_mode {
+    # Continuous recording is better for security & compliance compared to daily
+    # recording. However, it's potentially expensive in accounts with frequent updates
+    # to resources. If costs get out of hand, then it's probably best to override the
+    # recording frequency of frequently-updated resource types to daily, or even change
+    # the default to daily, at least for non-prod stages.
+    recording_frequency = "CONTINUOUS"
+  }
+}
+
+resource "aws_config_delivery_channel" "main" {
+  name = "main-${var.stage}"
+
+  # This bucket is created in each stage's security account by the config capability.
+  # I'm not crazy about hardcoding the bucket name here, but I'm even less crazy about
+  # all the other methods of fetching or passing in the bucket name. Maybe I'll change
+  # my mind in the future and refactor this, but in the meantime, I'll simply add a
+  # comment above the resource declaration for this bucket noting that if its name is
+  # ever changed, then this reference to it must be updated as well.
+  s3_bucket_name = "devshrekops-demo-config-logs-${var.stage}"
+
+  snapshot_delivery_properties {
+    # By default, Config only delivers configuration history files to the S3 bucket, not
+    # configuration snapshot files. Setting the delivery frequency here enables snapshot
+    # files to be delivered too. History files are delivered every 6 hours, but only
+    # include configuration items for resources that changed since the last delivery.
+    # Snapshots are delivered every 24 hours (per the below) and contain the
+    # configuration items for all supported resources, regardless of when they last
+    # changed.
+    delivery_frequency = "TwentyFour_Hours"
+  }
+
+  # AWS requires that the Config recorder exists before the delivery channel can be
+  # created, but Terraform isn't able to infer that dependency, since none of the
+  # delivery channel's arguments reference the recorder, so the dependency must be
+  # explicitly configured.
+  depends_on = [aws_config_configuration_recorder.main]
+}
+
+resource "aws_config_configuration_recorder_status" "main" {
+  name       = aws_config_configuration_recorder.main.name
+  is_enabled = true
+
+  # AWS requires that the Config delivery channel exists before the recorder can be
+  # enabled, but Terraform isn't able to infer that dependency, since none of the
+  # recorder status' arguments reference the delivery channel, so the dependency must be
+  # explicitly configured.
+  depends_on = [aws_config_delivery_channel.main]
+}

--- a/modules/account-baseline/regional/variables.tf
+++ b/modules/account-baseline/regional/variables.tf
@@ -7,3 +7,9 @@ variable "stage" {
   type        = string
   nullable    = false
 }
+
+variable "config_svc_role_arn" {
+  description = "ARN of the IAM service-linked role for Config in this account."
+  type        = string
+  nullable    = false
+}


### PR DESCRIPTION
Terraform plan for **mgmt-prod**: [tf-plan-mgmt-prod.txt](https://github.com/user-attachments/files/16755416/tf-plan-mgmt-prod.txt)

Terraform plan for **sec-prod**: [tf-plan-sec-prod.txt](https://github.com/user-attachments/files/16755422/tf-plan-sec-prod.txt)

The same changes were already applied to **mgmt-dev** and **sec-dev** during development.