### PR TITLE
org: Add active & closed OUs

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -35,6 +35,20 @@ resource "aws_organizations_organization" "main" {
 }
 
 ## -------------------------------------------------------------------------------------
+## ORGANIZATIONAL UNITS (OUs)
+## -------------------------------------------------------------------------------------
+
+resource "aws_organizations_organizational_unit" "active" {
+  name      = "active-${var.stage}"
+  parent_id = aws_organizations_organization.main.roots[0].id
+}
+
+resource "aws_organizations_organizational_unit" "closed" {
+  name      = "closed-${var.stage}"
+  parent_id = aws_organizations_organization.main.roots[0].id
+}
+
+## -------------------------------------------------------------------------------------
 ## ACCOUNT FACTORY
 ## -------------------------------------------------------------------------------------
 
@@ -47,10 +61,7 @@ resource "aws_organizations_account" "main" {
   name  = "demo-${each.key}-${var.stage}"
   email = "devshrekops+demo-${each.key}-${var.stage}@gmail.com"
 
-  # An OU structure will be created in the future, but for now all accounts will go into
-  # the root of the org. This is the default behavior, but explicitly setting it anyway
-  # so that Terraform will perform drift detection on any manual changes to parent ID.
-  parent_id = aws_organizations_organization.main.roots[0].id
+  parent_id = aws_organizations_organizational_unit.active.id
 
   close_on_deletion          = true
   iam_user_access_to_billing = "ALLOW"

--- a/capabilities/org/resources/outputs.tf
+++ b/capabilities/org/resources/outputs.tf
@@ -23,3 +23,11 @@ output "org_roots" {
   description = "Roots of the org."
   value       = aws_organizations_organization.main.roots
 }
+
+output "ou_ids" {
+  description = "IDs of the OUs in the org."
+  value = {
+    "active" : aws_organizations_organizational_unit.active.id
+    "closed" : aws_organizations_organizational_unit.closed.id
+  }
+}


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_account.main["mgmt"] will be updated in-place
  ~ resource "aws_organizations_account" "main" {
        id                = "339712815005"
        name              = "demo-mgmt-prod"
      ~ parent_id         = "r-zjd8" -> (known after apply)
        tags              = {
            "account-key" = "mgmt"
        }
        # (8 unchanged attributes hidden)
    }

  # module.org_resources.aws_organizations_account.main["sec"] will be updated in-place
  ~ resource "aws_organizations_account" "main" {
        id                = "590183735431"
        name              = "demo-sec-prod"
      ~ parent_id         = "r-zjd8" -> (known after apply)
        tags              = {
            "account-key" = "sec"
        }
        # (8 unchanged attributes hidden)
    }

  # module.org_resources.aws_organizations_organizational_unit.active will be created
  + resource "aws_organizations_organizational_unit" "active" {
      + accounts  = (known after apply)
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "active-prod"
      + parent_id = "r-zjd8"
      + tags_all  = (known after apply)
    }

  # module.org_resources.aws_organizations_organizational_unit.closed will be created
  + resource "aws_organizations_organizational_unit" "closed" {
      + accounts  = (known after apply)
      + arn       = (known after apply)
      + id        = (known after apply)
      + name      = "closed-prod"
      + parent_id = "r-zjd8"
      + tags_all  = (known after apply)
    }

Plan: 2 to add, 2 to change, 0 to destroy.

Changes to Outputs:
  ~ org_resources = {
      + ou_ids       = {
          + active = (known after apply)
          + closed = (known after apply)
        }
        # (3 unchanged attributes hidden)
    }
```

The same changes were already applied to **org-dev** during development.