### PR TITLE
org: Add deny-all SCP

### DIFF
--- a/capabilities/org/resources/outputs.tf
+++ b/capabilities/org/resources/outputs.tf
@@ -31,3 +31,10 @@ output "ou_ids" {
     "closed" : aws_organizations_organizational_unit.closed.id
   }
 }
+
+output "scp_ids" {
+  description = "IDs of the SCPs in the org."
+  value = {
+    "deny_all" : aws_organizations_policy.deny_all.id
+  }
+}


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_organization.main will be updated in-place
  ~ resource "aws_organizations_organization" "main" {
      ~ enabled_policy_types          = [
          + "SERVICE_CONTROL_POLICY",
        ]
        id                            = "o-32fecjn1ln"
        # (10 unchanged attributes hidden)
    }

  # module.org_resources.aws_organizations_policy.deny_all will be created
  + resource "aws_organizations_policy" "deny_all" {
      + arn         = (known after apply)
      + content     = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "*"
                      + Effect   = "Deny"
                      + Resource = "*"
                      + Sid      = "DenyAllActionsOnAllResources"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + description = "Deny all actions on all resources by all principals."
      + id          = (known after apply)
      + name        = "deny-all-prod"
      + tags_all    = (known after apply)
      + type        = "SERVICE_CONTROL_POLICY"
    }

  # module.org_resources.aws_organizations_policy_attachment.closed_deny_all will be created
  + resource "aws_organizations_policy_attachment" "closed_deny_all" {
      + id        = (known after apply)
      + policy_id = (known after apply)
      + target_id = "ou-zjd8-i60i21ur"
    }

Plan: 2 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  ~ org_resources = {
      + scp_ids      = {
          + deny_all = (known after apply)
        }
        # (4 unchanged attributes hidden)
    }
```

The same changes were already applied to **org-dev** during development.