### PR TITLE
org: Replace org_roots output with org_root_id

### DIFF
--- a/capabilities/org/resources/outputs.tf
+++ b/capabilities/org/resources/outputs.tf
@@ -19,9 +19,9 @@ output "org_id" {
   value       = aws_organizations_organization.main.id
 }
 
-output "org_roots" {
-  description = "Roots of the org."
-  value       = aws_organizations_organization.main.roots
+output "org_root_id" {
+  description = "ID of the org's root."
+  value       = aws_organizations_organization.main.roots[0].id
 }
 
 output "ou_ids" {


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Changes to Outputs:
  ~ org_resources = {
      + org_root_id  = "r-zjd8"
      - org_roots    = [
          - {
              - arn          = "arn:aws:organizations::339712815005:root/o-32fecjn1ln/r-zjd8"
              - id           = "r-zjd8"
              - name         = "Root"
              - policy_types = [
                  - {
                      - status = "ENABLED"
                      - type   = "SERVICE_CONTROL_POLICY"
                    },
                ]
            },
        ]
        # (4 unchanged attributes hidden)
    }

You can apply this plan to save these new output values to the Terraform state, without changing any
real infrastructure.
```

The same changes were already applied to **org-dev** during development.
