### PR TITLE
org: Add baseline-guardrails SCP

### DIFF
--- a/capabilities/org/resources/outputs.tf
+++ b/capabilities/org/resources/outputs.tf
@@ -35,6 +35,7 @@ output "ou_ids" {
 output "scp_ids" {
   description = "IDs of the SCPs in the org."
   value = {
+    "baseline_guardrails" : aws_organizations_policy.baseline_guardrails.id
     "deny_all" : aws_organizations_policy.deny_all.id
   }
 }


### PR DESCRIPTION
Deny all actions on all resources in regions other than us-east-1 and us-west-2.

Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_policy.baseline_guardrails will be created
  + resource "aws_organizations_policy" "baseline_guardrails" {
      + arn         = (known after apply)
      + content     = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "*"
                      + Condition = {
                          + ArnNotLike      = {
                              + "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                          + StringNotEquals = {
                              + "aws:RequestedRegion" = [
                                  + "us-east-1",
                                  + "us-west-2",
                                ]
                            }
                        }
                      + Effect    = "Deny"
                      + Resource  = "*"
                      + Sid       = "DenyActionsInDisallowedRegions"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + description = "Baseline security controls applied to all AWS accounts."
      + id          = (known after apply)
      + name        = "baseline-guardrails-prod"
      + tags_all    = (known after apply)
      + type        = "SERVICE_CONTROL_POLICY"
    }

  # module.org_resources.aws_organizations_policy_attachment.active_baseline_guardrails will be created
  + resource "aws_organizations_policy_attachment" "active_baseline_guardrails" {
      + id        = (known after apply)
      + policy_id = (known after apply)
      + target_id = "ou-zjd8-f7ik47x1"
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ org_resources = {
      ~ scp_ids      = {
          + baseline_guardrails = (known after apply)
            # (1 unchanged attribute hidden)
        }
        # (4 unchanged attributes hidden)
    }
```

The same changes were already applied to **org-dev** during development.