### PR TITLE
org: Include TF deployer in region restrictions

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -132,16 +132,6 @@ data "aws_iam_policy_document" "baseline_guardrails" {
         "us-west-2", # Oregon
       ]
     }
-
-    # Exempt the Terraform deployer role from region restrictions, at least for now
-    # while there are still Terraform-managed resources deployed into all regions.
-    condition {
-      test     = "ArnNotLike"
-      variable = "aws:PrincipalARN"
-      values = [
-        "arn:aws:iam::*:role/tf-deployer-${var.stage}"
-      ]
-    }
   }
 }
 


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_policy.baseline_guardrails will be updated in-place
  ~ resource "aws_organizations_policy" "baseline_guardrails" {
      ~ content     = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          - ArnNotLike      = {
                              - "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                            # (1 unchanged attribute hidden)
                        }
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id          = "p-c10vfdtb"
        name        = "baseline-guardrails-prod"
        tags        = {}
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

Similar changes already applied to **org-dev** during development.