### PR TITLE
misc: Add default tags to all AWS providers

### DIFF
--- a/accounts/mgmt/dev/config.tf
+++ b/accounts/mgmt/dev/config.tf
@@ -35,12 +35,24 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "dev"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "accounts/mgmt/dev"
+  }
+}
+
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -50,6 +62,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/accounts/mgmt/prod/config.tf
+++ b/accounts/mgmt/prod/config.tf
@@ -35,12 +35,24 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "prod"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "accounts/mgmt/prod"
+  }
+}
+
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -50,6 +62,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/accounts/sec/dev/config.tf
+++ b/accounts/sec/dev/config.tf
@@ -35,12 +35,24 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "dev"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "accounts/sec/dev"
+  }
+}
+
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -50,6 +62,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/accounts/sec/prod/config.tf
+++ b/accounts/sec/prod/config.tf
@@ -35,12 +35,24 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "prod"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "accounts/sec/prod"
+  }
+}
+
 provider "aws" {
   alias  = "us_east_1"
   region = "us-east-1"
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -50,6 +62,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/capabilities/cloudtrail/dev/config.tf
+++ b/capabilities/cloudtrail/dev/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "dev"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/cloudtrail/dev"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,6 +64,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/capabilities/cloudtrail/prod/config.tf
+++ b/capabilities/cloudtrail/prod/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "prod"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/cloudtrail/prod"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,6 +64,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/capabilities/config/dev/config.tf
+++ b/capabilities/config/dev/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "dev"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/config/dev"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,5 +64,9 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/capabilities/config/prod/config.tf
+++ b/capabilities/config/prod/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "prod"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/config/prod"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,5 +64,9 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/capabilities/guardduty/dev/config.tf
+++ b/capabilities/guardduty/dev/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "dev"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/guardduty/dev"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,6 +64,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -64,6 +80,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -72,6 +92,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::891377308296:role/tf-deployer-dev"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 

--- a/capabilities/guardduty/prod/config.tf
+++ b/capabilities/guardduty/prod/config.tf
@@ -35,6 +35,14 @@ terraform {
 ## PROVIDERS
 ## -------------------------------------------------------------------------------------
 
+locals {
+  default_tags = {
+    "devshrekops:demo:stage"          = "prod"
+    "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+    "devshrekops:demo:tf-config-path" = "capabilities/guardduty/prod"
+  }
+}
+
 # us-east-1
 
 provider "aws" {
@@ -44,6 +52,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -52,6 +64,10 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }
 
@@ -64,6 +80,10 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod"
   }
+
+  default_tags {
+    tags = local.default_tags
+  }
 }
 
 provider "aws" {
@@ -72,5 +92,9 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::590183735431:role/tf-deployer-prod"
+  }
+
+  default_tags {
+    tags = local.default_tags
   }
 }

--- a/capabilities/org/dev/config.tf
+++ b/capabilities/org/dev/config.tf
@@ -41,6 +41,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev" # mgmt-dev
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "dev"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/org/dev"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------

--- a/capabilities/org/prod/config.tf
+++ b/capabilities/org/prod/config.tf
@@ -41,6 +41,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod" # mgmt-prod
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "prod"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/org/prod"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------

--- a/capabilities/sso/dev/config.tf
+++ b/capabilities/sso/dev/config.tf
@@ -41,6 +41,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev" # mgmt-dev
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "dev"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/sso/dev"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------

--- a/capabilities/sso/prod/config.tf
+++ b/capabilities/sso/prod/config.tf
@@ -41,6 +41,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod" # mgmt-prod
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "prod"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/sso/prod"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------

--- a/capabilities/tf-state-backend/dev/config.tf
+++ b/capabilities/tf-state-backend/dev/config.tf
@@ -46,6 +46,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::533266992459:role/tf-deployer-dev" # mgmt-dev
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "dev"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/tf-state-backend/dev"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------

--- a/capabilities/tf-state-backend/prod/config.tf
+++ b/capabilities/tf-state-backend/prod/config.tf
@@ -46,6 +46,14 @@ provider "aws" {
   assume_role {
     role_arn = "arn:aws:iam::339712815005:role/tf-deployer-prod" # mgmt-prod
   }
+
+  default_tags {
+    tags = {
+      "devshrekops:demo:stage"          = "prod"
+      "devshrekops:demo:tf-config-repo" = "aws-org-tf-demo"
+      "devshrekops:demo:tf-config-path" = "capabilities/tf-state-backend/prod"
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform plans: [tf-plans.txt](https://github.com/user-attachments/files/16842600/tf-plans.txt)

The same changes were already applied to all dev Terraform configs during development.