### PR TITLE
org: Protect tags created by Terraform

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -133,6 +133,32 @@ data "aws_iam_policy_document" "baseline_guardrails" {
       ]
     }
   }
+
+  # Only allow the Terraform deployer role to create, modify, & delete tags that begin
+  # with "devshrekops:demo:". These tags are reserved for use by the Terraform configs
+  # in this repo.
+  statement {
+    sid       = "ProtectTerraformTags"
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:TagKeys"
+      values = [
+        "devshrekops:demo:*",
+      ]
+    }
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalARN"
+      values = [
+        "arn:aws:iam::*:role/tf-deployer-${var.stage}",
+      ]
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_policy.baseline_guardrails will be updated in-place
  ~ resource "aws_organizations_policy" "baseline_guardrails" {
      ~ content     = jsonencode(
          ~ {
              ~ Statement = [
                    {
                        Action    = "*"
                        Condition = {
                            StringNotEquals = {
                                "aws:RequestedRegion" = [
                                    "us-east-1",
                                    "us-west-2",
                                ]
                            }
                        }
                        Effect    = "Deny"
                        Resource  = "*"
                        Sid       = "DenyActionsInDisallowedRegions"
                    },
                  + {
                      + Action    = "*"
                      + Condition = {
                          + ArnNotLike               = {
                              + "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                          + "ForAnyValue:StringLike" = {
                              + "aws:TagKeys" = "devshrekops:demo:*"
                            }
                        }
                      + Effect    = "Deny"
                      + Resource  = "*"
                      + Sid       = "ProtectTerraformTags"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id          = "p-c10vfdtb"
        name        = "baseline-guardrails-prod"
        tags        = {}
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The same changes were already applied to dev via **org-dev**.