### PR TITLE
org: Add baseline guardrails for Config

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -159,6 +159,31 @@ data "aws_iam_policy_document" "baseline_guardrails" {
       ]
     }
   }
+
+  # Only allow the Terraform deployer role to perform some write actions in some
+  # services. This statement is focused on actions that are simple to deny, without
+  # needing to narrow the policy statement down by resource ARN nor condition.
+  statement {
+    sid    = "SimpleGuardrails"
+    effect = "Deny"
+    actions = [
+      # Prevent out-of-band changes to AWS Config resources that are created & managed
+      # via Terraform configs in this repo (or are likely to be in the future).
+      "config:Delete*",
+      "config:Put*",
+      "config:Tag*",
+      "config:Untag*",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnNotLike"
+      variable = "aws:PrincipalARN"
+      values = [
+        "arn:aws:iam::*:role/tf-deployer-${var.stage}",
+      ]
+    }
+  }
 }
 
 ## -------------------------------------------------------------------------------------


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_policy.baseline_guardrails will be updated in-place
  ~ resource "aws_organizations_policy" "baseline_guardrails" {
      ~ content     = jsonencode(
          ~ {
              ~ Statement = [
                    # (1 unchanged element hidden)
                    {
                        Action    = "*"
                        Condition = {
                            ArnNotLike               = {
                                "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                            "ForAnyValue:StringLike" = {
                                "aws:TagKeys" = "devshrekops:demo:*"
                            }
                        }
                        Effect    = "Deny"
                        Resource  = "*"
                        Sid       = "ProtectTerraformTags"
                    },
                  + {
                      + Action    = [
                          + "config:Untag*",
                          + "config:Tag*",
                          + "config:Put*",
                          + "config:Delete*",
                        ]
                      + Condition = {
                          + ArnNotLike = {
                              + "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                        }
                      + Effect    = "Deny"
                      + Resource  = "*"
                      + Sid       = "SimpleGuardrails"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id          = "p-c10vfdtb"
        name        = "baseline-guardrails-prod"
        tags        = {}
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The same changes were already applied to dev via **org-dev**.