### PR TITLE
org: Add baseline guardrails for Organizations

### DIFF
--- a/capabilities/org/resources/main.tf
+++ b/capabilities/org/resources/main.tf
@@ -134,9 +134,9 @@ data "aws_iam_policy_document" "baseline_guardrails" {
     }
   }
 
-  # Only allow the Terraform deployer role to create, modify, & delete tags that begin
-  # with "devshrekops:demo:". These tags are reserved for use by the Terraform configs
-  # in this repo.
+  # Don't allow any principal other than the Terraform deployer role to create, modify,
+  # & delete tags that begin with "devshrekops:demo:". These tags are reserved for use
+  # by the Terraform configs in this repo.
   statement {
     sid       = "ProtectTerraformTags"
     effect    = "Deny"
@@ -160,8 +160,9 @@ data "aws_iam_policy_document" "baseline_guardrails" {
     }
   }
 
-  # Only allow the Terraform deployer role to perform certain write actions, regardless
-  # of any other factors, such as resource ARN or tags.
+  # Don't allow certain write actions to be performed by any principal other than the
+  # Terraform deployer role, regardless of any other factors, such as resource ARN or
+  # tags.
   statement {
     sid    = "SimpleGuardrails"
     effect = "Deny"
@@ -185,6 +186,26 @@ data "aws_iam_policy_document" "baseline_guardrails" {
       "guardduty:Tag*",
       "guardduty:Untag*",
       "guardduty:Update*",
+      "organizations:Accept*",
+      "organizations:Attach*",
+      "organizations:Cancel*",
+      "organizations:Close*",
+      "organizations:Create*",
+      "organizations:Decline*",
+      "organizations:Delete*",
+      "organizations:Deregister*",
+      "organizations:Detach*",
+      "organizations:Disable*",
+      "organizations:Enable*",
+      "organizations:Invite*",
+      "organizations:Leave*",
+      "organizations:Move*",
+      "organizations:Put*",
+      "organizations:Register*",
+      "organizations:Remove*",
+      "organizations:Tag*",
+      "organizations:Untag*",
+      "organizations:Update*",
     ]
     resources = ["*"]
 
@@ -197,8 +218,8 @@ data "aws_iam_policy_document" "baseline_guardrails" {
     }
   }
 
-  # Only allow the Terraform deployer role to perform certain write actions on resources
-  # that have a tag with key "devshrekops:demo:stage".
+  # Don't allow certain write actions to be performed by any principal other than the
+  # Terraform deployer role on resources that have a "devshrekops:demo:stage" tag.
   statement {
     sid    = "TagBasedGuardrails"
     effect = "Deny"


### PR DESCRIPTION
Terraform plan for **org-prod**:

```
Terraform will perform the following actions:

  # module.org_resources.aws_organizations_policy.baseline_guardrails will be updated in-place
  ~ resource "aws_organizations_policy" "baseline_guardrails" {
      ~ content     = jsonencode(
          ~ {
              ~ Statement = [
                    # (1 unchanged element hidden)
                    {
                        Action    = "*"
                        Condition = {
                            ArnNotLike               = {
                                "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                            "ForAnyValue:StringLike" = {
                                "aws:TagKeys" = "devshrekops:demo:*"
                            }
                        }
                        Effect    = "Deny"
                        Resource  = "*"
                        Sid       = "ProtectTerraformTags"
                    },
                  ~ {
                      ~ Action    = [
                          + "organizations:Update*",
                          + "organizations:Untag*",
                          + "organizations:Tag*",
                          + "organizations:Remove*",
                          + "organizations:Register*",
                          + "organizations:Put*",
                          + "organizations:Move*",
                          + "organizations:Leave*",
                          + "organizations:Invite*",
                          + "organizations:Enable*",
                          + "organizations:Disable*",
                          + "organizations:Detach*",
                          + "organizations:Deregister*",
                          + "organizations:Delete*",
                          + "organizations:Decline*",
                          + "organizations:Create*",
                          + "organizations:Close*",
                          + "organizations:Cancel*",
                          + "organizations:Attach*",
                          + "organizations:Accept*",
                            "guardduty:Update*",
                            # (18 unchanged elements hidden)
                        ]
                        # (4 unchanged attributes hidden)
                    },
                    {
                        Action    = [
                            "cloudtrail:Update*",
                            "cloudtrail:Stop*",
                            "cloudtrail:Start*",
                            "cloudtrail:Remove*",
                            "cloudtrail:Put*",
                            "cloudtrail:Delete*",
                            "cloudtrail:Add*",
                        ]
                        Condition = {
                            ArnNotLike = {
                                "aws:PrincipalARN" = "arn:aws:iam::*:role/tf-deployer-prod"
                            }
                            StringLike = {
                                "aws:ResourceTag/devshrekops:demo:stage" = "*"
                            }
                        }
                        Effect    = "Deny"
                        Resource  = "*"
                        Sid       = "TagBasedGuardrails"
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
        id          = "p-c10vfdtb"
        name        = "baseline-guardrails-prod"
        tags        = {}
        # (4 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The same changes were already applied to dev via **org-dev**.